### PR TITLE
First rs_minicbor commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# TPS API Reference Implementations
+
+This project provides a set of reference implementations for specifications created
+by the [GlobalPlatform](https://globalplatform.org) Trusted Platform Services
+Committee and its Working Groups.
+
+The Trusted Platform Services Committee aims to create APIs which allow application
+developers to use standardized security services hosted on Secure Components such as
+a Trusted Execution Environment, a Secure Element or a Trusted Platform Module (TPM).
+
+The Trusted Platform Services APIs make heavy use of
+[CBOR](https://www.rfc-editor.org/info/rfc8949) and related technologies such as 
+[COSE](https://www.rfc-editor.org/info/rfc8152) and 
+[CDDL](https://www.rfc-editor.org/info/rfc8610), which are standardized by the IETF.
+
+The reference implementations on this site are, where appropriate, intended to be
+usable on relatively constrained embedded microcontroller platforms (circa 200-500kB RAM/ROM).
+
+As this is a new project, we have preference for contributions in the
+[Rust](https://rust-lang.org) programming language.
+
+## License
+
+Contributions *and their dependencies* must be MIT licensed or provided under a
+compatible license. Dual-licensed (Apache 2 OR MIT) dependencies, which are
+common in the Rust language ecosystem, are fine.
+
+## Components
+
+- [**`rs_minicbor`**](rs_minicbor/README.md): An implementation of
+  [RFC 8949 Concise Binary Object Representation (CBOR)](https://www.rfc-editor.org/rfc/rfc8949) 
+  intended for use on embedded platforms, or other places where the developer requires more
+  control over serialization and deserialization than something like SERDE CBOR.

--- a/rs_minicbor/Cargo.toml
+++ b/rs_minicbor/Cargo.toml
@@ -1,0 +1,60 @@
+# Copyright (c) 2020, 2021 Jeremy O'Donoghue. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+# and associated documentation files (the “Software”), to deal in the Software without
+# restriction, including without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or
+# substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# rs_minicbor package definition
+
+[package]
+name = "rs_minicbor"
+version = "0.1.0"
+authors = ["Jeremy O'Donoghue<quic_jodonogh@quicinc.com"]
+edition = "2018"
+license = "MIT"
+license-file = "LICENSE.txt"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+# rs_minicbor can be built in the following variants:
+# - embedded: (no_std) No allocator or standard library required. Logging, indefinite length messaging
+#   and high-level API are not allowed as a consequence since these require an allocator.
+# - default: (std) Requires standard library. Optionally supports logging, indefinite length messaging and a
+#   higher-level API which can be easier to use.
+
+[features]
+default = ["combinators", "std_tags"]
+embedded = ["no_std", "combinators"]
+tiny = ["no_std"]
+
+std = []                    # Standard library available
+no_std = []                 # Do not use standard library
+trace = ["std"]             # Perform tracing on function entry/exit (for debug). Requires std
+float = []                  # Support floating point operations
+std_tags = ["float", "std"] # Support RFC7049 tagged values for date/time. Requires std and float
+combinators = []            # Support higher-level APIs for encoding and decoding
+
+# Where dependencies are dual-licensed, this project uses the MIT license
+
+[dependencies]
+thiserror = "1.0.30"        # Dual-licensed, MIT or Apache-2.0
+half = "1.8.2"              # Dual-licensed, MIT or Apache-2.0
+func_trace = "1.0.3"        # MIT licensed
+chrono = "0.4.19"           # Dual-licensed, MIT or Apache-2.0
+
+[profile.release]
+opt-level = 'z'   # Optimize for size.
+lto = true        # Link time optimization
+codegen-units = 1 # Optimize for size at expense of compile time
+panic = "abort"   # No unwinding

--- a/rs_minicbor/LICENSE
+++ b/rs_minicbor/LICENSE
@@ -1,0 +1,15 @@
+Copyright © 2020, 2021 Jeremy O'Donoghue. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rs_minicbor/README.md
+++ b/rs_minicbor/README.md
@@ -1,0 +1,43 @@
+# RS-MINICBOR
+
+An implementation of CBOR in Rust which is aimed at relatively constrained embedded
+systems where the Serde implementation is not necessarily well suited.
+
+## License
+
+`rs_minicbor` is MIT licensed. See LICENSE.
+
+## API requirements
+
+- Needs to work in a `#[no_std]` environment.
+- Needs to handle unaligned data for primitive types.
+    - Decode Trait?
+- Should support Iterator traits, consistent with small implementation.
+  - `fn core::iter::Iterator::next(&mut self) -> Option<Self::Item>`
+  - `fn core::iter::IntoIterator::into_iter(self) -> Self::IntoIter`
+    - Shared reference to collection as input -> iterator producing shatred references to items
+  - `fn iter()` and `fn iter_mut()`.
+    - `iter()` also produces a shared reference to items
+    - `iter_mut()` produces mutable references to items
+    - See [Stackoverflow answer](https://stackoverflow.com/questions/34733811/what-is-the-difference-between-iter-and-into-iter/34745885#34745885).
+- Should be able to turn a `tstr` into `&str`, retaining the lifetime of the
+  underlying buffer.
+- Should be able to nest into arrays and maps to at least a reasonable depth.
+- Should support CBOR sequences encoded as `bstr`
+- Nice to have: can be driven by CDDL, or by some form of CDDL state machine.
+  Reasonable restrictions are allowed.
+- Needs to support search in maps
+- CBOR arrays will be treated as slices from an API perspective, but note that we
+  do not always have same type for each array entry.
+  - `fn len(&self) -> usize` returns array length.
+  - `fn first(&self) -> Option<&T>` returns first element (None if empty).
+  - `fn split_first(&self) -> Option<(&T, &[T])>` splits at first element and rest.
+  - `fn last(&self) -> Option<&T>` returns last element.
+  - `fn get<I>(&self, index: I) n-> Option<&<I as SliceIndex<[T]>>::Output>`
+- CBOR maps will be treated as similar to HashMap from an API perspective. Again
+  we do not always have the same type for each map entry.
+  - `fn len(&self) -> usize` returns number of elements in map.
+  - `fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>` where Q is the type of keys and
+    V is the type of values (which can be any CBOR value). It is allowed to constrain
+    keys to integers and `tstr`s.
+

--- a/rs_minicbor/examples/decode.rs
+++ b/rs_minicbor/examples/decode.rs
@@ -1,0 +1,57 @@
+/***************************************************************************************************
+ * Copyright (c) 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+
+extern crate rs_minicbor;
+
+use rs_minicbor::decoder::*;
+use rs_minicbor::types::*;
+
+use std::convert::TryFrom;
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Just about simplest ever: the below decodes as 1000
+    let b = SequenceBuffer::new(&[0x19, 0x03, 0xe8]);
+    let mut it = b.into_iter();
+    let item = it.next();
+
+    if let Some(item) = item {
+        let v1 = u16::try_from(&item); // should succeed
+        let v2 = u32::try_from(&item); // should succeed
+        let v3 = i32::try_from(&item); // should succeed
+        let v4 = u8::try_from(&item); // should fail
+        println!("v1 = {:?}, v2 = {:?}, v3 = {:?}, v4 = {:?}", v1, v2, v3, v4);
+    }
+
+    // Testing how to use combinators
+    let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8]).into_iter();
+    let (it, r1) = is_uint()(it)?;
+    let (_next, v) = cond(true, &is_eof())(it)?;
+    //let (_next, v) = cond!(false, is_eof, it)?;
+    //let (_next, v) = is_eof()(it)?;
+    println!("r1 = {:?}, e = {:?}", r1, v);
+
+    let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8, 0x19, 0x03, 0xe9]).into_iter();
+    let (it, r1) = opt(apply(&is_uint(), |v| {
+        println!("Value: {:?}", v);
+    }))(it)?;
+    let (_it, r2) = is_uint()(it)?;
+    assert!(r1 == Some(CBOR::UInt(1000)) && r2 == CBOR::UInt(1001));
+    Ok(())
+}

--- a/rs_minicbor/src/array.rs
+++ b/rs_minicbor/src/array.rs
@@ -1,0 +1,100 @@
+/***************************************************************************************************
+ * Copyright (c) 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * rs_minicbor CBOR Array deserialser API
+ *
+ * A fairly comprehensive, memory efficient, deserializer and serializer for CBOR (RFC7049).
+ * This implementation is designed for use in constrained systems and requires neither the Rust
+ * standard library nor an allocator.
+ **************************************************************************************************/
+use crate::ast::CBOR;
+use crate::decode::{DecodeBufIterator, DecodeBufIteratorSource};
+
+#[cfg(feature = "trace")]
+use func_trace::trace;
+
+#[cfg(feature = "trace")]
+func_trace::init_depth_var!();
+
+/// A buffer which contains a CBOR Array to be decoded. The buffer has lifetime `'buf`,
+/// which must be longer than any borrow from the buffer itself. This is generally used to represent
+/// a CBOR array with an exposed slice-like API.
+///
+/// This CBOR buffer implementation does not support indefinite length items.
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub struct ArrayBuf<'buf> {
+    bytes: &'buf [u8],
+    n_items: usize,
+}
+
+impl<'buf> ArrayBuf<'buf> {
+    /// Construct a new instance of `ArrayBuf` with all context initialized.
+    #[cfg_attr(feature = "trace", trace)]
+    pub fn new(init: &'buf [u8], n_items: usize) -> ArrayBuf<'buf> {
+        ArrayBuf {
+            bytes: init,
+            n_items,
+        }
+    }
+
+    /// Return the number of items in the `ArrayBuf`.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.n_items
+    }
+
+    /// Return `true` if `ArrayBuf` is empty.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.n_items == 0 && self.bytes.len() == 0
+    }
+
+    /// Return the `n`th value (zero indexed) in the `ArrayBuf`.
+    ///
+    /// Worst case performance of this function is O(n) in standalone form, but performance is
+    /// likely to be O(n^2) if used for random access in general.
+    #[cfg_attr(feature = "trace", trace)]
+    pub fn index(&self, n: usize) -> Option<CBOR> {
+        let mut count = 0;
+        let mut it = self.into_iter();
+        let mut item = it.next();
+        while count < n && Option::is_some(&item) {
+            item = it.next();
+            count += 1;
+        }
+        item
+    }
+}
+
+impl<'buf> IntoIterator for ArrayBuf<'buf> {
+    type Item = CBOR<'buf>;
+    type IntoIter = DecodeBufIterator<'buf>;
+
+    /// Construct an Iterator adapter from a `DecodeBuf`.
+    #[cfg_attr(feature = "trace", trace)]
+    fn into_iter(self) -> Self::IntoIter {
+        DecodeBufIterator {
+            buf: self.bytes,
+            index: 0,
+            source: DecodeBufIteratorSource::Array,
+        }
+    }
+}

--- a/rs_minicbor/src/ast.rs
+++ b/rs_minicbor/src/ast.rs
@@ -1,0 +1,545 @@
+/***************************************************************************************************
+ * Copyright (c) 2020, 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * CBOR Abstract Syntax Tree
+ *
+ * A fairly comprehensive, memory efficient, deserializer and serializer for CBOR (RFC7049).
+ * This implementation is designed for use in constrained systems and requires neither the Rust
+ * standard library nor an allocator.
+ **************************************************************************************************/
+use crate::array::ArrayBuf;
+use crate::error::{CBORError, Result};
+use crate::map::MapBuf;
+use crate::tag::TagBuf;
+
+use std::convert::TryFrom;
+use std::mem::transmute;
+
+#[cfg(feature = "float")]
+use half::f16;
+
+#[cfg(any(feature = "std_tags", test))]
+use chrono::{DateTime, FixedOffset};
+
+#[cfg(feature = "trace")]
+use func_trace::trace;
+
+#[cfg(feature = "trace")]
+func_trace::init_depth_var!();
+
+/// The data type for CBOR Items. CBOR types may borrow immutably from an underlying buffer which
+/// must therefore outlive the item itself - this is the 'buf lifetime.
+///
+/// CBOR item representations are as follows:
+///
+/// - Positive and negative integers are stored as a u64 with enum tags used to distinguish
+///   positive (UInt) and negative (NInt) numbers
+/// - The bstr and tstr types are held as immutable borrowed slices over the CBOR parse buffer
+/// - Simple types are stored as a u8
+/// - Arrays are stored as a number of items and an immutable borrowed slice over the contents of
+///   the array
+/// - Maps are stored as a number of pairs and an immutable borrowed slice over the contents of the
+///   map
+#[derive(PartialEq, Debug, Clone)]
+#[cfg(any(feature = "std_tags", test))]
+pub enum CBOR<'buf> {
+    UInt(u64),
+    NInt(u64),
+    Float64(f64),
+    Float32(f32),
+    Float16(f16),
+    Bstr(&'buf [u8]),
+    Tstr(&'buf str),
+    Array(ArrayBuf<'buf>),
+    Map(MapBuf<'buf>),
+    Tag(TagBuf<'buf>),
+    Simple(u8),
+    False,
+    True,
+    Null,
+    Undefined,
+    Eof,
+    // The following are the std_tags extensions
+    DateTime(DateTime<FixedOffset>),
+    Epoch(i64),
+}
+
+// Manual implementation needed as there is no Copy instance for BigInt
+#[cfg(any(feature = "std_tags", test))]
+impl<'buf> Copy for CBOR<'buf> {}
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg(all(feature = "float", not(feature = "std_tags"), not(test)))]
+pub enum CBOR<'buf> {
+    UInt(u64),
+    NInt(u64),
+    Float64(f64),
+    Float32(f32),
+    Float16(f16),
+    Bstr(&'buf [u8]),
+    Tstr(&'buf str),
+    Array(ArrayBuf<'buf>),
+    Map(MapBuf<'buf>),
+    Tag(TagBuf<'buf>),
+    Simple(u8),
+    False,
+    True,
+    Null,
+    Undefined,
+    Eof,
+}
+
+// This variant used when Floating point operations are not included
+#[cfg(all(not(feature = "float"), not(test)))]
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub enum CBOR<'buf> {
+    UInt(u64),
+    NInt(u64),
+    Bstr(&'buf [u8]),
+    Tstr(&'buf str),
+    Array(ArrayBuf<'buf>),
+    Map(MapBuf<'buf>),
+    Tag(TagBuf<'buf>),
+    Simple(u8),
+    False,
+    True,
+    Null,
+    Undefined,
+    Eof,
+}
+
+impl<'buf> CBOR<'buf> {
+    /// Attempt to convert CBOR into u8
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn try_into_u8(self) -> Result<u8> {
+        if let Self::UInt(v) = self {
+            if v <= u8::MAX as u64 {
+                Ok(v as u8)
+            } else {
+                Err(CBORError::OutOfRange)
+            }
+        } else {
+            Err(CBORError::IncompatibleType)
+        }
+    }
+
+    /// Attempt to convert CBOR into u16
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn try_into_u16(self) -> Result<u16> {
+        if let Self::UInt(v) = self {
+            if v <= u16::MAX as u64 {
+                Ok(v as u16)
+            } else {
+                Err(CBORError::OutOfRange)
+            }
+        } else {
+            Err(CBORError::IncompatibleType)
+        }
+    }
+
+    /// Attempt to convert CBOR into u32
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn try_into_u32(self) -> Result<u32> {
+        if let Self::UInt(v) = self {
+            if v <= u32::MAX as u64 {
+                Ok(v as u32)
+            } else {
+                Err(CBORError::OutOfRange)
+            }
+        } else {
+            Err(CBORError::IncompatibleType)
+        }
+    }
+
+    /// Attempt to convert CBOR into u64
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn try_into_u64(self) -> Result<u64> {
+        if let Self::UInt(v) = self {
+            Ok(v)
+        } else {
+            Err(CBORError::IncompatibleType)
+        }
+    }
+
+    /// Attempt to convert CBOR into u64
+    ///
+    /// This will always succeed for integer values as CBOR only supports values over 64 bits
+    /// which all fit on 128 bits.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn try_into_i128(self) -> Result<i128> {
+        match self {
+            // Positive integer.
+            Self::UInt(v) => Ok(v as i128),
+            // Negative integer. Add one to the stored uint
+            Self::NInt(v) => Ok(-1 - (v as i128)),
+            _ => Err(CBORError::IncompatibleType),
+        }
+    }
+
+    /// Attempt to convert CBOR into i64
+    ///
+    /// This will fail, for unsigned values, if n > i64::MAX
+    /// This will fail, for signed values, if n < i64::MIN
+    ///
+    /// For positive values it is sufficient to check the MSB is not set (MSB used for 2's
+    /// complement sign)
+    ///
+    /// For negative values it is also sufficient to check that the MSB is not set. This is because
+    /// it gives us a minimum value of -1 - (2^(n-1) - 1), for example, if we have the value -128
+    /// (i8::MIN), it is represented as 1 - 127. Similar rules apply for all signed types.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn try_into_i64(self) -> Result<i64> {
+        match self {
+            // Positive integer.
+            Self::UInt(val) => {
+                if val & 1 << 63 == 0 {
+                    // Good case. Transmute relies on internal representation of integers
+                    Ok(unsafe { transmute::<u64, i64>(val) })
+                } else {
+                    // Overflow case
+                    Err(CBORError::OutOfRange)
+                }
+            }
+            // Negative integer. Add one to the stored uint
+            Self::NInt(val) => {
+                if val & 1 << 63 == 0 {
+                    // 2's complement (only the complement required as store -1 -n
+                    let v = !val;
+                    Ok(unsafe { transmute::<u64, i64>(v) })
+                } else {
+                    // Overflow
+                    Err(CBORError::OutOfRange)
+                }
+            }
+            _ => Err(CBORError::IncompatibleType),
+        }
+    }
+
+    /// Attempt to convert CBOR into i32
+    ///
+    /// This will fail, for unsigned values, if n > i32::MAX
+    /// This will fail, for signed values, if n < i32::MIN
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn try_into_i32(self) -> Result<i32> {
+        match self {
+            // Positive integer.
+            Self::UInt(val) => {
+                if val <= i32::MAX as u64 {
+                    Ok(val as i32)
+                } else {
+                    // Overflow case
+                    Err(CBORError::OutOfRange)
+                }
+            }
+            // Negative integer.
+            Self::NInt(val) => {
+                // Unsigned value is checked against i32::MAX as encoding 1 - val
+                if val <= i32::MAX as u64 {
+                    Ok(-1 - (val as i32))
+                } else {
+                    Err(CBORError::OutOfRange)
+                }
+            }
+            _ => Err(CBORError::IncompatibleType),
+        }
+    }
+
+    /// Attempt to convert CBOR into i16
+    /// This will fail, for unsigned values, if n > i16::MAX
+    /// This will fail, for signed values, if n < i16::MIN
+    ///
+    /// For positive values it is sufficient to check the MSB is not set (MSB used for 2's
+    /// complement sign)
+    ///
+    /// For negative values it is also sufficient to check that the MSB is not set. This is because
+    /// it gives us a minimum value of -1 - (2^(n-1) - 1), for example, if we have the value -128
+    /// (i8::MIN), it is represented as 1 - 127. Similar rules apply for all signed types.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn try_into_i16(self) -> Result<i16> {
+        match self {
+            // Positive integer.
+            Self::UInt(val) => {
+                if val <= i16::MAX as u64 {
+                    Ok(val as i16)
+                } else {
+                    // Overflow case
+                    Err(CBORError::OutOfRange)
+                }
+            }
+            // Negative integer.
+            Self::NInt(val) => {
+                // Unsigned value is checked against i32::MAX as encoding 1 - val
+                if val <= i16::MAX as u64 {
+                    Ok(-1 - (val as i16))
+                } else {
+                    Err(CBORError::OutOfRange)
+                }
+            }
+            _ => Err(CBORError::IncompatibleType),
+        }
+    }
+
+    /// Attempt to convert CBOR into i8
+    ///
+    /// This will fail, for unsigned values, if n > i8::MAX
+    /// This will fail, for signed values, if n < i8::MIN
+    ///
+    /// For positive values it is sufficient to check the MSB is not set (MSB used for 2's
+    /// complement sign)
+    ///
+    /// For negative values it is also sufficient to check that the MSB is not set. This is because
+    /// it gives us a minimum value of -1 - (2^(n-1) - 1), for example, if we have the value -128
+    /// (i8::MIN), it is represented as 1 - 127. Similar rules apply for all signed types.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn try_into_i8(self) -> Result<i8> {
+        match self {
+            // Positive integer.
+            Self::UInt(val) => {
+                if val <= i8::MAX as u64 {
+                    Ok(val as i8)
+                } else {
+                    // Overflow case
+                    Err(CBORError::OutOfRange)
+                }
+            }
+            // Negative integer.
+            Self::NInt(val) => {
+                // Unsigned value is checked against i32::MAX as encoding 1 - val
+                if val <= i8::MAX as u64 {
+                    Ok(-1 - (val as i8))
+                } else {
+                    Err(CBORError::OutOfRange)
+                }
+            }
+            _ => Err(CBORError::IncompatibleType),
+        }
+    }
+
+    /// Read a str slice.
+    #[inline]
+    pub fn try_into_str(&self) -> Result<&'buf str> {
+        match self {
+            Self::Tstr(s) => Ok(s),
+            _ => Err(CBORError::IncompatibleType),
+        }
+    }
+
+    /// Read a [u8] slice.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn try_into_u8slice(&self) -> Result<&'buf [u8]> {
+        match self {
+            Self::Bstr(bytes) => Ok(*bytes),
+            _ => Err(CBORError::IncompatibleType),
+        }
+    }
+
+    /// Turn `u8` into `CBOR`
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn from_u8(v: u8) -> Self {
+        Self::UInt(v as u64)
+    }
+
+    /// Turn `u16` into `CBOR`
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn from_u16(v: u16) -> Self {
+        Self::UInt(v as u64)
+    }
+
+    /// Turn `u32` into `CBOR`
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn from_u32(v: u32) -> Self {
+        Self::UInt(v as u64)
+    }
+
+    /// Turn `u64` into `CBOR`
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn from_u64(v: u64) -> Self {
+        Self::UInt(v)
+    }
+
+    /// Turn `i8` into `CBOR`
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn from_i8(v: i8) -> Self {
+        if v < 0 {
+            Self::NInt((-1 - (v as i64)) as u64)
+        } else {
+            Self::UInt(v as u64)
+        }
+    }
+
+    /// Turn `i16` into `CBOR`
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn from_i16(v: i16) -> Self {
+        if v < 0 {
+            Self::NInt((-1 - (v as i64)) as u64)
+        } else {
+            Self::UInt(v as u64)
+        }
+    }
+
+    /// Turn `i32` into `CBOR`
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn from_i32(v: i32) -> Self {
+        if v < 0 {
+            Self::NInt((-1 - (v as i64)) as u64)
+        } else {
+            Self::UInt(v as u64)
+        }
+    }
+
+    /// Turn `i64` into `CBOR`
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn from_i64(v: i64) -> Self {
+        if v < 0 {
+            Self::NInt((-1 - (v as i64)) as u64)
+        } else {
+            Self::UInt(v as u64)
+        }
+    }
+
+    /// Turn `&str` into `CBOR`
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn from_str(v: &'buf str) -> Self {
+        Self::Tstr(v)
+    }
+
+    /// Turn `&[u8]` into `CBOR`
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn from_u8slice(v: &'buf [u8]) -> Self {
+        Self::Bstr(v)
+    }
+}
+
+impl<'buf> TryFrom<&'buf CBOR<'buf>> for u8 {
+    type Error = CBORError;
+
+    #[cfg_attr(feature = "trace", trace)]
+    fn try_from(value: &'buf CBOR) -> core::result::Result<Self, Self::Error> {
+        (*value).try_into_u8()
+    }
+}
+
+impl<'buf> TryFrom<&'buf CBOR<'buf>> for u16 {
+    type Error = CBORError;
+
+    #[cfg_attr(feature = "trace", trace)]
+    fn try_from(value: &'buf CBOR) -> core::result::Result<Self, Self::Error> {
+        (*value).try_into_u16()
+    }
+}
+
+impl<'buf> TryFrom<&'buf CBOR<'buf>> for u32 {
+    type Error = CBORError;
+
+    #[cfg_attr(feature = "trace", trace)]
+    fn try_from(value: &'buf CBOR) -> core::result::Result<Self, Self::Error> {
+        (*value).try_into_u32()
+    }
+}
+
+impl<'buf> TryFrom<&'buf CBOR<'buf>> for u64 {
+    type Error = CBORError;
+
+    #[cfg_attr(feature = "trace", trace)]
+    fn try_from(value: &'buf CBOR) -> core::result::Result<Self, Self::Error> {
+        (*value).try_into_u64()
+    }
+}
+
+impl<'buf> TryFrom<&'buf CBOR<'buf>> for i8 {
+    type Error = CBORError;
+
+    #[cfg_attr(feature = "trace", trace)]
+    fn try_from(value: &'buf CBOR) -> core::result::Result<Self, Self::Error> {
+        (*value).try_into_i8()
+    }
+}
+
+impl<'buf> TryFrom<&'buf CBOR<'buf>> for i16 {
+    type Error = CBORError;
+
+    #[cfg_attr(feature = "trace", trace)]
+    fn try_from(value: &'buf CBOR) -> core::result::Result<Self, Self::Error> {
+        (*value).try_into_i16()
+    }
+}
+
+impl<'buf> TryFrom<&'buf CBOR<'buf>> for i32 {
+    type Error = CBORError;
+
+    fn try_from(value: &'buf CBOR) -> core::result::Result<Self, Self::Error> {
+        (*value).try_into_i32()
+    }
+}
+
+impl<'buf> TryFrom<&'buf CBOR<'buf>> for i64 {
+    type Error = CBORError;
+
+    #[cfg_attr(feature = "trace", trace)]
+    fn try_from(value: &'buf CBOR) -> core::result::Result<Self, Self::Error> {
+        (*value).try_into_i64()
+    }
+}
+
+impl<'buf> TryFrom<&'buf CBOR<'buf>> for i128 {
+    type Error = CBORError;
+
+    #[cfg_attr(feature = "trace", trace)]
+    fn try_from(value: &'buf CBOR) -> core::result::Result<Self, Self::Error> {
+        (*value).try_into_i128()
+    }
+}
+
+impl<'buf> TryFrom<&'buf CBOR<'buf>> for &'buf str {
+    type Error = CBORError;
+
+    #[cfg_attr(feature = "trace", trace)]
+    fn try_from(value: &'buf CBOR) -> core::result::Result<Self, Self::Error> {
+        (*value).try_into_str()
+    }
+}
+
+impl<'buf> TryFrom<&'buf CBOR<'buf>> for &'buf [u8] {
+    type Error = CBORError;
+
+    #[cfg_attr(feature = "trace", trace)]
+    fn try_from(value: &'buf CBOR) -> core::result::Result<Self, Self::Error> {
+        (*value).try_into_u8slice()
+    }
+}

--- a/rs_minicbor/src/constants.rs
+++ b/rs_minicbor/src/constants.rs
@@ -1,0 +1,77 @@
+/***************************************************************************************************
+ * Copyright (c) 2020, 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * rs_minicbor CBOR constants
+ *
+ * A fairly comprehensive, memory efficient, deserializer and serializer for CBOR (RFC7049).
+ * This implementation is designed for use in constrained systems and requires neither the Rust
+ * standard library nor an allocator.
+ **************************************************************************************************/
+// Major type bitmask
+//pub const MT_MASK: u8 = 0b111_00000;
+/// Additional Information bitmask
+pub const AI_MASK: u8 = 0b000_11111;
+
+/// Major Type 0 (Positive integers)
+pub const MT_UINT: u8 = 0b000_00000;
+/// Major Type 1 (Negative integers)
+pub const MT_NINT: u8 = 0b001_00000;
+/// Major Type 2 (Byte Strings)
+pub const MT_BSTR: u8 = 0b010_00000;
+/// Major Type 3 (Text Strings)
+pub const MT_TSTR: u8 = 0b011_00000;
+/// Major Type 4 (Array)
+pub const MT_ARRAY: u8 = 0b100_00000;
+/// Major Type 5 (Map)
+pub const MT_MAP: u8 = 0b101_00000;
+/// Major Type 6 (Tag)
+pub const MT_TAG: u8 = 0b110_00000;
+/// Major Type 7 (Floats, simple types etc.)
+pub const MT_SIMPLE: u8 = 0b111_00000;
+pub const MT_FLOAT: u8 = 0b111_00000;
+
+/// Maximum value of a "simple" payload mapped on AI bits
+pub const PAYLOAD_AI_BITS: u8 = 23;
+/// Indicates one byte of length of value information follows MT/AI byte
+pub const PAYLOAD_ONE_BYTE: u8 = 24;
+/// Indicates two bytes of length of value information follows MT/AI byte
+pub const PAYLOAD_TWO_BYTES: u8 = 25;
+/// Indicates four bytes of length of value information follows MT/AI byte
+pub const PAYLOAD_FOUR_BYTES: u8 = 26;
+/// Indicates eight bytes of length of value information follows MT/AI byte
+pub const PAYLOAD_EIGHT_BYTES: u8 = 27;
+// Indicates an indefinite number of bytes follow. Note that this option is not supported
+// in the current version of rs_minicbor.
+//pub const PAYLOAD_INDEFINITE_BYTES: u8 = 31;
+
+/// Module defining bitfield values for what types are allowed by the filter trait. See
+/// `Allowable`.
+#[cfg(feature = "combinators")]
+pub mod allow {
+    pub const NONE: u32 = 1;
+    pub const UINT: u32 = 2;
+    pub const NINT: u32 = 4;
+    pub const BSTR: u32 = 8;
+    pub const TSTR: u32 = 16;
+    pub const ARRAY: u32 = 32;
+    pub const MAP: u32 = 64;
+    pub const TAG: u32 = 128;
+    pub const FLOAT: u32 = 256;
+    pub const SIMPLE: u32 = 512;
+}

--- a/rs_minicbor/src/decode.rs
+++ b/rs_minicbor/src/decode.rs
@@ -1,0 +1,507 @@
+/***************************************************************************************************
+ * Copyright (c) 2020, 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * CBOR Decoder
+ *
+ * A fairly comprehensive, memory efficient, deserializer for CBOR (RFC8949).
+ * This implementation is designed for use in constrained systems and requires neither the Rust
+ * standard library nor an allocator.
+ **************************************************************************************************/
+use crate::array::ArrayBuf;
+use crate::ast::CBOR;
+use crate::constants::*;
+use crate::decode::DecodeBufIteratorSource::Sequence;
+use crate::error::{CBORError, Result};
+use crate::map::MapBuf;
+use crate::tag::TagBuf;
+use crate::utils::within;
+
+use std::convert::TryInto;
+use std::mem::size_of;
+use std::str::from_utf8;
+
+#[cfg(feature = "float")]
+use half::f16;
+
+#[cfg(feature = "trace")]
+use func_trace::trace;
+
+#[cfg(feature = "trace")]
+func_trace::init_depth_var!();
+
+/***************************************************************************************************
+ * Integer parsing assistance
+ **************************************************************************************************/
+
+/// Value obtained by reading an unsigned value, retaining original representation.
+#[derive(Debug)]
+pub enum AnyUnsigned {
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+}
+
+impl<'buf> AnyUnsigned {
+    /// Convert `AnyUnsigned` into a `usize`. ALways succeeds.
+    #[cfg_attr(feature = "trace", trace)]
+    fn as_usize(self) -> usize {
+        match self {
+            Self::U8(v) => v as usize,
+            Self::U16(v) => v as usize,
+            Self::U32(v) => v as usize,
+            Self::U64(v) => v as usize,
+        }
+    }
+    /// Convert `AnyUnsigned` into a `u64`. ALways succeeds.
+    #[cfg_attr(feature = "trace", trace)]
+    fn as_u64(self) -> u64 {
+        match self {
+            Self::U8(v) => v as u64,
+            Self::U16(v) => v as u64,
+            Self::U32(v) => v as u64,
+            Self::U64(v) => v,
+        }
+    }
+    /// Convert `AnyUnsigned` into a `CBOR::Simple` value. We follow the rules in [RFC8949] for
+    /// Simple values: 20..23 have particular meanings; 24..31 are illegal; values must be encoded
+    /// on 8 bits (the larger values are encodings for floats).
+    #[cfg_attr(feature = "trace", trace)]
+    fn try_into_simple(self) -> Result<CBOR<'buf>> {
+        match self {
+            Self::U8(v) => match v {
+                0..=19 => Ok(CBOR::Simple(v)),
+                20 => Ok(CBOR::False),
+                21 => Ok(CBOR::True),
+                22 => Ok(CBOR::Null),
+                23 => Ok(CBOR::Undefined),
+                24..=31 => Err(CBORError::MalformedEncoding),
+                v => Ok(CBOR::Simple(v)),
+            },
+            _ => Err(CBORError::MalformedEncoding),
+        }
+    }
+}
+
+/***************************************************************************************************
+ * CBOR Sequence Buffer definitions
+ **************************************************************************************************/
+
+/// A buffer which contains a CBOR Sequence CBOR to be decoded. The buffer has lifetime `'buf`,
+/// which must be longer than any borrow from the buffer itself. This is generally used to represent
+/// an RFC8742 CBOR sequence with an exposed Iterator API, or as the top level structure generally
+/// for CBOR parsing.
+///
+/// This CBOR buffer implementation does not support indefinite length items.
+#[derive(Debug, Copy, Clone)]
+pub struct SequenceBuffer<'buf> {
+    pub bytes: &'buf [u8],
+}
+
+impl<'buf> SequenceBuffer<'buf> {
+    /// Construct a new instance of `DecodeBuf` with all context initialized.
+    #[cfg_attr(feature = "trace", trace)]
+    pub fn new(init: &'buf [u8]) -> SequenceBuffer<'buf> {
+        SequenceBuffer { bytes: init }
+    }
+}
+
+/// A `DecodeBufIterator` can be constructed from any of `SequenceBuffer`, `ArrayBuf`, `MapBuf`
+/// or `TagBuf`. We keep track of which of these was the source of the iterator as it has some
+/// impact on which combinator operations are allowed.
+#[derive(Debug, Clone, Copy)]
+pub enum DecodeBufIteratorSource {
+    Sequence,
+    Array,
+    Map,
+    Tag,
+}
+
+/// `DecodeBuffer` Iterator adapter to keep track of current position in `DecodeBuf`.
+#[derive(Debug, Clone, Copy)]
+pub struct DecodeBufIterator<'buf> {
+    /// This is the `DecodeBuf` itself. It's a simple wrapper around a reference.
+    pub buf: &'buf [u8],
+    /// The current position in `buf`.
+    pub index: usize,
+    /// The source of this `DecodeBufIterator instance.
+    pub source: DecodeBufIteratorSource,
+}
+
+impl<'buf> IntoIterator for SequenceBuffer<'buf> {
+    type Item = CBOR<'buf>;
+    type IntoIter = DecodeBufIterator<'buf>;
+
+    /// Construct an Iterator adapter from a `DecodeBuf`.
+    #[cfg_attr(feature = "trace", trace)]
+    fn into_iter(self) -> Self::IntoIter {
+        DecodeBufIterator {
+            buf: self.bytes,
+            index: 0,
+            source: Sequence,
+        }
+    }
+}
+
+impl<'buf> DecodeBufIterator<'buf> {
+    /// Parse a single CBOR item from DecodeBufIterator. On exit, `self.index` will point at the
+    /// start of the next item (if there is one)
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    fn item(&mut self) -> Result<CBOR<'buf>> {
+        let (next_index, cbor) = parse_item(self.buf, self.index)?;
+        self.index = next_index;
+        Ok(cbor)
+    }
+}
+
+impl<'buf> Iterator for DecodeBufIterator<'buf> {
+    type Item = CBOR<'buf>;
+
+    #[cfg_attr(feature = "trace", trace)]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.buf.len() {
+            match self.item() {
+                Ok(it) => Some(it),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+}
+/***************************************************************************************************
+ * CBOR Parser
+ **************************************************************************************************/
+
+/// Basic function for parsing a single CBOR Item from `buf` starting at `start_index`.
+///
+/// Assuming that all goes well, a pair, `(usize, CBOR)` is returned where the `usize` value is the
+/// index in `buf` of the next item in `buf` - this may be outside the bounds of `buf`, and must
+/// be checked before it is used. This function does bounds checking, so it is safe to use a
+/// previously returned next item index as an error will be returned if it is out of bounds.
+#[cfg(all(feature = "float", feature = "std_tags"))]
+fn parse_item(buf: &[u8], start_index: usize) -> Result<(usize, CBOR)> {
+    if within(buf, start_index, 0) {
+        let mt_ai_byte = buf[start_index];
+        match mt_ai_byte {
+            // Positive integers
+            0x00..=0x1b => parse_unsigned(buf, start_index)
+                .map(|(next_idx, val)| (next_idx, CBOR::UInt(val.as_u64()))),
+            // Negative integers
+            0x20..=0x3b => parse_unsigned(buf, start_index)
+                .map(|(next_idx, val)| (next_idx, CBOR::NInt(val.as_u64()))),
+            // Byte Strings
+            0x40..=0x5b => parse_bytestring(buf, start_index)
+                .map(|(next_idx, bytes)| (next_idx, CBOR::Bstr(bytes))),
+            // TODO: 0x5f - indefinite length byte string
+            // UTF8 strings
+            0x60..=0x7b => {
+                let (next_index, raw_bytes) = parse_bytestring(buf, start_index)?;
+                match from_utf8(&raw_bytes) {
+                    Ok(s) => Ok((next_index, CBOR::Tstr(s))),
+                    Err(_) => Err(CBORError::UTF8Error),
+                }
+            }
+            // TODO: 0x7f - indefinite length string
+            // Arrays
+            0x80..=0x9b => parse_array(buf, start_index),
+            // TODO: 0x9f - indefinite length array
+            // Maps
+            0xa0..=0xbb => parse_map(buf, start_index),
+            // TODO: 0xbf - indefinite length map
+            // Tagged values
+            0xc0..=0xdb => parse_tag(buf, start_index),
+            // Simple values
+            0xe0..=0xf8 => {
+                let (next_index, v) = parse_unsigned(buf, start_index)?;
+                Ok((next_index, v.try_into_simple()?))
+            }
+            0xf9 => {
+                let (next_index, val) = parse_f16(buf, start_index)?;
+                Ok((next_index, CBOR::Float16(val)))
+            }
+            0xfa => {
+                let (next_index, val) = parse_f32(buf, start_index)?;
+                Ok((next_index, CBOR::Float32(val)))
+            }
+            0xfb => {
+                let (next_index, val) = parse_f64(buf, start_index)?;
+                Ok((next_index, CBOR::Float64(val)))
+            }
+            _ => Err(CBORError::NotImplemented),
+        }
+    } else {
+        Err(CBORError::EndOfBuffer)
+    }
+}
+
+// Version for no float and no std_tags
+#[cfg(not(feature = "float"))]
+fn parse_item(buf: &[u8], start_index: usize) -> Result<(usize, CBOR)> {
+    if within(buf, start_index, 0) {
+        let mt_ai_byte = buf[start_index];
+        match mt_ai_byte {
+            // Positive integers
+            0x00..=0x1b => parse_unsigned(buf, start_index)
+                .map(|(next_idx, val)| (next_idx, CBOR::UInt(val.as_u64()))),
+            // Negative integers
+            0x20..=0x3b => parse_unsigned(buf, start_index)
+                .map(|(next_idx, val)| (next_idx, CBOR::NInt(val.as_u64()))),
+            // Byte Strings
+            0x40..=0x5b => parse_bytestring(buf, start_index)
+                .map(|(next_idx, bytes)| (next_idx, CBOR::Bstr(bytes))),
+            // TODO: 0x5f - indefinite length byte string
+            // UTF8 strings
+            0x60..=0x7b => {
+                let (next_index, raw_bytes) = parse_bytestring(buf, start_index)?;
+                match from_utf8(&raw_bytes) {
+                    Ok(s) => Ok((next_index, CBOR::Tstr(s))),
+                    Err(_) => Err(CBORError::UTF8Error),
+                }
+            }
+            // TODO: 0x7f - indefinite length string
+            // Arrays
+            0x80..=0x9b => parse_array(buf, start_index),
+            // TODO: 0x9f - indefinite length array
+            // Maps
+            0xa0..=0xbb => parse_map(buf, start_index),
+            // TODO: 0xbf - indefinite length map
+            // Tagged values
+            0xc0..=0xdb => parse_tag(buf, start_index),
+            // Simple values
+            0xe0..=0xf8 => {
+                let (next_index, v) = parse_unsigned(buf, start_index)?;
+                Ok((next_index, v.try_into_simple()?))
+            }
+            _ => Err(CBORError::NotImplemented),
+        }
+    } else {
+        Err(CBORError::EndOfBuffer)
+    }
+}
+
+/***************************************************************************************************
+ * Integer parser helpers
+ **************************************************************************************************/
+
+/// Parse an unsigned integer value.
+///
+/// On entry the `start` index is assumed to identify an MT/AI byte within `buf`.
+/// On return we have a sized unsigned integer value and the index within `buf` of the next value.
+#[cfg_attr(feature = "trace", trace)]
+pub(crate) fn parse_unsigned(buf: &[u8], start_index: usize) -> Result<(usize, AnyUnsigned)> {
+    // We do not care about the value of the MT bits
+    if within(buf, start_index, 0) {
+        let ai = buf[start_index] & AI_MASK;
+        if ai <= PAYLOAD_AI_BITS {
+            Ok((start_index + size_of::<u8>(), AnyUnsigned::U8(ai)))
+        } else if ai == PAYLOAD_ONE_BYTE {
+            let (next_index, item_slice) = read_extent(buf, start_index + 1, size_of::<u8>())?;
+            let result: core::result::Result<[u8; 1], _> = item_slice.try_into();
+            match result {
+                Ok(bytes) => Ok((next_index, AnyUnsigned::U8(u8::from_be_bytes(bytes)))),
+                Err(_) => Err(CBORError::BadSliceLength),
+            }
+        } else if ai == PAYLOAD_TWO_BYTES {
+            let (next_index, item_slice) = read_extent(buf, start_index + 1, size_of::<u16>())?;
+            let result: core::result::Result<[u8; 2], _> = item_slice.try_into();
+            match result {
+                Ok(bytes) => Ok((next_index, AnyUnsigned::U16(u16::from_be_bytes(bytes)))),
+                Err(_) => Err(CBORError::BadSliceLength),
+            }
+        } else if ai == PAYLOAD_FOUR_BYTES {
+            let (next_index, item_slice) = read_extent(buf, start_index + 1, size_of::<u32>())?;
+            let result: core::result::Result<[u8; 4], _> = item_slice.try_into();
+            match result {
+                Ok(bytes) => Ok((next_index, AnyUnsigned::U32(u32::from_be_bytes(bytes)))),
+                Err(_) => Err(CBORError::BadSliceLength),
+            }
+        } else if ai == PAYLOAD_EIGHT_BYTES {
+            let (next_index, item_slice) = read_extent(buf, start_index + 1, size_of::<u64>())?;
+            let result: core::result::Result<[u8; 8], _> = item_slice.try_into();
+            match result {
+                Ok(bytes) => Ok((next_index, AnyUnsigned::U64(u64::from_be_bytes(bytes)))),
+                Err(_) => Err(CBORError::BadSliceLength),
+            }
+        } else {
+            Err(CBORError::MalformedEncoding)
+        }
+    } else {
+        Err(CBORError::EndOfBuffer)
+    }
+}
+
+/***************************************************************************************************
+ * Float Parse Helpers
+ **************************************************************************************************/
+
+/// Parse a 64bit floating point value.
+///
+/// On entry the `start` index is assumed to identify an MT/AI byte within `buf`.
+/// On return we have an `f64` value and the index within `buf` of the next value.
+#[cfg(feature = "float")]
+#[cfg_attr(feature = "trace", trace)]
+fn parse_f64(buf: &[u8], start_index: usize) -> Result<(usize, f64)> {
+    let (next_index, item_slice) = read_extent(buf, start_index + 1, size_of::<f64>())?;
+    let result: core::result::Result<[u8; 8], _> = item_slice.try_into();
+    match result {
+        Ok(bytes) => Ok((next_index, f64::from_be_bytes(bytes))),
+        Err(_) => Err(CBORError::BadSliceLength),
+    }
+}
+
+/// Parse a 32bit floating point value.
+///
+/// On entry the `start` index is assumed to identify an MT/AI byte within `buf`.
+/// On return we have an `f32` value and the index within `buf` of the next value.
+#[cfg(feature = "float")]
+#[cfg_attr(feature = "trace", trace)]
+fn parse_f32(buf: &[u8], start_index: usize) -> Result<(usize, f32)> {
+    let (next_index, item_slice) = read_extent(buf, start_index + 1, size_of::<f32>())?;
+    let result: core::result::Result<[u8; 4], _> = item_slice.try_into();
+    match result {
+        Ok(bytes) => Ok((next_index, f32::from_be_bytes(bytes))),
+        Err(_) => Err(CBORError::BadSliceLength),
+    }
+}
+
+/// Parse a 16bit floating point value.
+///
+/// On entry the `start` index is assumed to identify an MT/AI byte within `buf`.
+/// On return we have an `f16` value and the index within `buf` of the next value.
+#[cfg(feature = "float")]
+#[cfg_attr(feature = "trace", trace)]
+fn parse_f16(buf: &[u8], start_index: usize) -> Result<(usize, f16)> {
+    let (next_index, item_slice) = read_extent(buf, start_index + 1, size_of::<f16>())?;
+    let result: core::result::Result<[u8; 2], _> = item_slice.try_into();
+    match result {
+        Ok(bytes) => Ok((next_index, f16::from_be_bytes(bytes))),
+        Err(_) => Err(CBORError::BadSliceLength),
+    }
+}
+
+/***************************************************************************************************
+ * Bytestring, Arrays, Maps and String Helpers
+ **************************************************************************************************/
+
+/// Parse a bytestring starting at `start_index` in buffer `buf`. The index `start_index` should
+/// indicate the MT/AI byte for the item to be parsed.
+#[cfg_attr(feature = "trace", trace)]
+pub(crate) fn parse_bytestring(buf: &[u8], start_index: usize) -> Result<(usize, &[u8])> {
+    let (start_bstr_index, value) = parse_unsigned(buf, start_index)?;
+    let length = value.as_usize();
+    let (next_item_index, bytes) = read_extent(buf, start_bstr_index, length)?;
+    Ok((next_item_index, bytes))
+}
+
+/// Parse an array. An array of length N is simply a sequence of N CBOR Items, some of which
+/// could themselves be arrays or maps.
+///
+/// In order to avoid heap allocation we return a typed buffer which itself can be mapped over
+/// with an iterator and other helpful API functions resembling the slice API provided by Rust
+/// as standard.
+#[cfg_attr(feature = "trace", trace)]
+fn parse_array(buf: &[u8], start_index: usize) -> Result<(usize, CBOR)> {
+    let (array_start_index, u_value) = parse_unsigned(buf, start_index)?;
+    let n_items = u_value.as_usize();
+    let next_index = skip_items(buf, array_start_index, n_items)?;
+
+    // No need to check that length + index is legal - already checked in skip_item
+    Ok((
+        next_index,
+        CBOR::Array(ArrayBuf::new(&buf[array_start_index..next_index], n_items)),
+    ))
+}
+
+/// Parse a map. An map of N items is simply a sequence of N*2 CBOR Items, some of which
+/// could themselves be arrays or maps.
+///
+/// In order to avoid heap allocation we return a typed buffer which itself can be mapped over
+/// with an iterator and other helpful API functions resembling the slice API provided by Rust
+/// as standard.
+#[cfg_attr(feature = "trace", trace)]
+fn parse_map(buf: &[u8], start_index: usize) -> Result<(usize, CBOR)> {
+    let (array_start_index, value) = parse_unsigned(buf, start_index)?;
+    let n_pairs = value.as_usize();
+    let n_items = n_pairs * 2; // We read pairs of Items
+    let next_index = skip_items(buf, array_start_index, n_items)?;
+
+    // No need to check that length + index is legal - already checked in skip_item
+    Ok((
+        next_index,
+        CBOR::Map(MapBuf::new(&buf[array_start_index..next_index], n_pairs)),
+    ))
+}
+
+/// Parse a tagged item. An Item tagged with N is followed by a single CBOR Item, which
+/// could be an array or map.
+///
+/// In order to avoid heap allocation we return a typed buffer which itself can be mapped over
+/// with an iterator and other helpful API functions resembling the slice API provided by Rust
+/// as standard.
+#[cfg_attr(feature = "trace", trace)]
+fn parse_tag(buf: &[u8], start_index: usize) -> Result<(usize, CBOR)> {
+    let (tag_item_start_index, tag_value) = parse_unsigned(buf, start_index)?;
+    let next_index = parse_item(buf, tag_item_start_index)?.0;
+    Ok((
+        next_index,
+        CBOR::Tag(TagBuf::new(
+            &buf[tag_item_start_index..next_index],
+            tag_value.as_u64(),
+        )),
+    ))
+}
+
+/***************************************************************************************************
+ * Other helpers
+ **************************************************************************************************/
+
+/// Try to skip over N Items, returning the index (which may be out of bounds) of the start of the
+/// N+1 thItem.
+///
+/// There is no "parse" variant for this function because, in a no_std environment, we have no way
+/// to return a sequence of CBOR directly.
+#[cfg_attr(feature = "trace", trace)]
+fn skip_items(buf: &[u8], start_index: usize, n_items: usize) -> Result<usize> {
+    let mut next_index = start_index;
+
+    // We only call skip_items() if we are parsing an array, map or tagged item. In each case we
+    // have already parsed the length component, which means that if `n_items` is zero,
+    // `start_index` is alreay the index of the next item.
+    // The call to `parse_item()` fails if we overflow the buffer.
+    if n_items > 0 {
+        for _i in 0..n_items {
+            next_index = parse_item(buf, next_index)?.0;
+        }
+        Ok(next_index)
+    } else {
+        Ok(start_index)
+    }
+}
+
+/// Return the index of the next item to parse and a slice over the item within `buf`.
+#[cfg_attr(feature = "trace", trace)]
+fn read_extent(buf: &[u8], start: usize, length: usize) -> Result<(usize, &[u8])> {
+    if within(buf, start, length) {
+        Ok((start + length, &buf[start..start + length]))
+    } else {
+        Err(CBORError::EndOfBuffer)
+    }
+}

--- a/rs_minicbor/src/decode_combinators.rs
+++ b/rs_minicbor/src/decode_combinators.rs
@@ -1,0 +1,827 @@
+/***************************************************************************************************
+ * Copyright (c) 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * CBOR Decoder Combinators
+ *
+ * A fairly comprehensive, memory efficient, deserializer for CBOR (RFC7049). This deserializer
+ * is designed for use in constrained systems and requires neither the Rust standard library
+ * nor an allocator.
+ *
+ * The decode combinators do make use of dynamic dispatch and have some memory penalty in return
+ * for a more comfortable API. They can be disabled using the `embedded` build feature.
+ **************************************************************************************************/
+use crate::ast::CBOR;
+use crate::decode::{DecodeBufIterator, SequenceBuffer};
+use crate::error::CBORError;
+
+use std::convert::From;
+
+/// Alias for the Result type for all CBOR decode combinators.
+type DCResult<'buf> = core::result::Result<(DecodeBufIterator<'buf>, CBOR<'buf>), CBORError>;
+/// Alias for the Result type where the output type, `O`, is generic.
+type DCPResult<'buf, O> = core::result::Result<(DecodeBufIterator<'buf>, O), CBORError>;
+
+/***************************************************************************************************
+ * Top Level Decoder API
+ **************************************************************************************************/
+
+#[cfg(feature = "combinators")]
+pub struct CBORDecoder<'buf> {
+    decode_buf_iter: DecodeBufIterator<'buf>,
+}
+
+#[cfg(feature = "combinators")]
+impl<'buf> CBORDecoder<'buf> {
+    /// Construct a new instance of a `CBORDecoder` from a `SequenceBuffer`.
+    #[inline]
+    pub fn new(b: SequenceBuffer<'buf>) -> Self {
+        Self {
+            decode_buf_iter: b.into_iter(),
+        }
+    }
+
+    /// Construct a new instance of a `CBORDecoder` from a `SequenceBuffer`.
+    #[inline]
+    pub fn from_slice(b: &'buf [u8]) -> Self {
+        Self {
+            decode_buf_iter: SequenceBuffer::new(b).into_iter(),
+        }
+    }
+
+    /// Construct an instance of `CBORDecoder` from the CBOR item enclosed within a Tag, allowing
+    /// decode within a CBOR Tag using the CBORDecoder API.
+    #[inline]
+    pub fn from_tag(cbor: CBOR<'buf>) -> Result<Self, CBORError> {
+        if let CBOR::Tag(tb) = cbor {
+            Ok(Self {
+                decode_buf_iter: tb.into_iter(),
+            })
+        } else {
+            Err(CBORError::ExpectedType("CBOR Map"))
+        }
+    }
+
+    /// Construct an instance of `CBORDecoder` from a CBOR Array, allowing decoding within a CBOR
+    /// Array using the CBORDecoder API.
+    #[inline]
+    pub fn from_array(cbor: CBOR<'buf>) -> Result<Self, CBORError> {
+        if let CBOR::Array(ab) = cbor {
+            Ok(Self {
+                decode_buf_iter: ab.into_iter(),
+            })
+        } else {
+            Err(CBORError::ExpectedType("CBOR Array"))
+        }
+    }
+
+    /// Construct an instance of `CBORDecoder` from a CBOR Array, allowing decoding within a CBOR
+    /// Map using the CBORDecoder API.
+    #[inline]
+    pub fn from_map(cbor: CBOR<'buf>) -> Result<Self, CBORError> {
+        if let CBOR::Map(mb) = cbor {
+            Ok(Self {
+                decode_buf_iter: mb.into_iter(),
+            })
+        } else {
+            Err(CBORError::ExpectedType("CBOR Map"))
+        }
+    }
+
+    /// When decoding maps, arrays and tags, the closures require finalizing to obtain
+    /// the correct return type.
+    #[inline]
+    pub fn finalize(&self) -> Result<(), CBORError> {
+        Ok(())
+    }
+
+    /// Run `parser` over the next item in the iterator. If it completes successfully, run
+    /// `closure` using the result obtained. This allows some result to be built up from
+    /// parsing.
+    ///
+    /// TODO: currently the lifetime management does not allow assignment of references to `self`
+    /// within the `closure`.
+    pub fn decode_with<F, C>(
+        &'buf mut self,
+        parser: F,
+        mut closure: C,
+    ) -> Result<&'buf mut Self, CBORError>
+    where
+        F: Fn(DecodeBufIterator<'buf>) -> DCResult<'buf>,
+        C: FnMut(CBOR<'buf>) -> Result<(), CBORError>,
+    {
+        let (it, cbor) = parser(self.decode_buf_iter.clone())?;
+        self.decode_buf_iter = it;
+        closure(cbor)?;
+        Ok(self)
+    }
+
+    /// Optionally run `parser` over the next item in the iterator. If parsing is successful,
+    /// run `closure` using the result obtained. If parsing is unsuccessful, continue with the
+    /// iterator state unchanged.
+    ///
+    /// TODO: currently the lifetime management does not allow assignment of references to `self`
+    /// within the `closure`.
+    pub fn opt<F, C>(&mut self, parser: F, closure: C) -> Result<&mut Self, CBORError>
+    where
+        F: Fn(DecodeBufIterator<'buf>) -> DCResult<'buf>,
+        C: Fn(CBOR<'buf>) -> Result<(), CBORError>,
+    {
+        let (it, opt_cbor) = opt(&parser)(self.decode_buf_iter.clone())?;
+        self.decode_buf_iter = it;
+        if let Some(cbor) = opt_cbor {
+            closure(cbor)?;
+        }
+        Ok(self)
+    }
+
+    /// Run `parser` over the next item in the iterator. If it completes successfully, do nothing.
+    /// If the parse fails, an error value will be returned.
+    #[inline]
+    pub fn ignore<F, C>(&mut self, parser: F) -> Result<&mut Self, CBORError>
+    where
+        F: Fn(DecodeBufIterator<'buf>) -> DCResult<'buf>,
+    {
+        let (it, _cbor) = parser(self.decode_buf_iter.clone())?;
+        self.decode_buf_iter = it;
+        Ok(self)
+    }
+
+    /// Run `parser` if `condition` is true. If parsing runs and is successful,
+    /// run `closure` using the result obtained.
+    ///
+    /// TODO: currently the lifetime management does not allow assignment of references to `self`
+    /// within the `closure`.
+    pub fn cond<F, C>(
+        &mut self,
+        condition: bool,
+        parser: F,
+        closure: C,
+    ) -> Result<&mut Self, CBORError>
+    where
+        F: Fn(DecodeBufIterator<'buf>) -> DCResult<'buf>,
+        C: Fn(CBOR<'buf>) -> Result<(), CBORError>,
+    {
+        if condition {
+            let (it, opt_cbor) = opt(&parser)(self.decode_buf_iter.clone())?;
+            self.decode_buf_iter = it;
+            if let Some(cbor) = opt_cbor {
+                closure(cbor)?;
+            }
+        }
+        Ok(self)
+    }
+
+    /// Run `parser` at least `min` and no more than `max` times. Each time `parser` executes
+    /// successfully, `closure` is executed with the result of the parse.
+    ///
+    /// Note that for the repetitive functions, the iteration number over the parser is passed
+    /// as well as the result of the parse.
+    ///
+    /// TODO: currently the lifetime management does not allow assignment of references to `self`
+    /// within the `closure`.
+    pub fn range<F, C>(
+        &mut self,
+        min: usize,
+        max: usize,
+        parser: F,
+        closure: C,
+    ) -> Result<&mut Self, CBORError>
+    where
+        F: Fn(DecodeBufIterator<'buf>) -> DCResult<'buf>,
+        C: Fn(usize, CBOR<'buf>) -> Result<(), CBORError>,
+    {
+        let mut no_parse = 0;
+
+        loop {
+            // Have to borrow parser here because we call many times.
+            let (it, opt_cbor) = opt(&parser)(self.decode_buf_iter.clone())?;
+            self.decode_buf_iter = it;
+            if let Some(cbor) = opt_cbor {
+                no_parse += 1;
+                closure(no_parse, cbor)?;
+            } else {
+                // Parse failed, but this is not necessarily an error
+                if no_parse < min && min != 0 {
+                    // Case 1: Failure: we have not parsed min no of times and min != 0
+                    return Err(CBORError::RangeUnderflow(no_parse));
+                } else {
+                    // Case 2: Success: we have parsed the minimum number of times or min == 0
+                    return Ok(self);
+                }
+            }
+            if no_parse == max {
+                // Case 3: we have parsed the maximum number of times
+                return Ok(self);
+            }
+        }
+    }
+
+    /// Execute `parser` zero or more times, calling `closure` each time `parser` executes
+    /// successfully.
+    ///
+    /// The `closure` function takes a `usize` for the iteration number and a `cbor` for the
+    /// result of the parse.
+    pub fn many0<F, C>(&mut self, parser: F, closure: C) -> Result<&mut Self, CBORError>
+    where
+        F: Fn(DecodeBufIterator<'buf>) -> DCResult<'buf>,
+        C: Fn(usize, CBOR<'buf>) -> Result<(), CBORError>,
+    {
+        self.range(0, usize::MAX, parser, closure)
+    }
+}
+
+/***************************************************************************************************
+ * CBOR decoding helpers
+ **************************************************************************************************/
+
+/// The CBOR parsing monad. Design is very similar to implementation of `Parser` in the `nom` crate.
+///
+/// `DecodeParser` provides functions to manipulate parsers in various useful ways.
+#[cfg(feature = "combinators")]
+pub trait DecodeParser<'buf, O> {
+    /// Parse monad: start with an input type and return `Result` containing (remaining input,
+    /// output) or an error.
+    ///
+    /// Instance must be provided.
+    fn parse(&self, input: DecodeBufIterator<'buf>) -> DCPResult<'buf, O>;
+
+    /// Map a function over the result of a parser.
+    fn map<F2, O2>(self, f2: F2) -> Map<Self, F2, O>
+    where
+        F2: Fn(O) -> O2,
+        Self: core::marker::Sized,
+    {
+        Map {
+            f1: self,
+            f2,
+            phantom: core::marker::PhantomData,
+        }
+    }
+
+    /// Create a second parser from the output of the first and apply this to remaining input
+    fn flat_map<F1, F2, O2>(self, f2: F2) -> FlatMap<Self, F2, O>
+    where
+        F1: Fn(O) -> F2,
+        F2: DecodeParser<'buf, O2>,
+        Self: core::marker::Sized,
+    {
+        FlatMap {
+            f1: self,
+            f2,
+            phantom: core::marker::PhantomData,
+        }
+    }
+
+    /// Apply a second parser over the first, returning results as a tuple
+    fn and<F2, O2>(self, f2: F2) -> And<Self, F2>
+    where
+        F2: DecodeParser<'buf, O2>,
+        Self: core::marker::Sized,
+    {
+        And { f1: self, f2 }
+    }
+
+    fn or<F2>(self, f2: F2) -> Or<Self, F2>
+    where
+        F2: DecodeParser<'buf, O>,
+        Self: core::marker::Sized,
+    {
+        Or { f1: self, f2 }
+    }
+
+    fn into<O2: From<O>>(self) -> Into<Self, O, O2>
+    where
+        Self: core::marker::Sized,
+    {
+        Into {
+            f: self,
+            phantom_o1: core::marker::PhantomData,
+            phantom_o2: core::marker::PhantomData,
+        }
+    }
+}
+
+/// This instance of `DecodeParser` allows any function `F` of type
+/// `Fn(DecodeBufIterator) -> DCPResult<O>' to be used as a `DecodeParser` instance, which
+/// simplifies the definition of all of the simple parsers.
+#[cfg(feature = "combinators")]
+impl<'buf, O, F> DecodeParser<'buf, O> for F
+where
+    F: Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, O>,
+{
+    fn parse(&self, i: DecodeBufIterator<'buf>) -> DCPResult<'buf, O> {
+        self(i)
+    }
+}
+
+/// Helper structure for `DecodeParser::map`.
+#[cfg(feature = "combinators")]
+pub struct Map<F1, F2, O1> {
+    f1: F1,
+    f2: F2,
+    phantom: core::marker::PhantomData<O1>,
+}
+
+#[cfg(feature = "combinators")]
+impl<'buf, O1, O2, F1: DecodeParser<'buf, O1>, F2: Fn(O1) -> O2> DecodeParser<'buf, O2>
+    for Map<F1, F2, O1>
+{
+    /// Parse over a `Map` structure.
+    fn parse(&self, i: DecodeBufIterator<'buf>) -> DCPResult<'buf, O2> {
+        match self.f1.parse(i) {
+            Ok((i2, o1)) => Ok((i2, (self.f2)(o1))),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Helper structure for `DecodeParser::flat_map`.
+#[cfg(feature = "combinators")]
+pub struct FlatMap<F1, F2, O1> {
+    f1: F1,
+    f2: F2,
+    phantom: core::marker::PhantomData<O1>,
+}
+
+#[cfg(feature = "combinators")]
+impl<'buf, O1, O2, F1: DecodeParser<'buf, O1>, F2: Fn(O1) -> P2, P2: DecodeParser<'buf, O2>>
+    DecodeParser<'buf, O2> for FlatMap<F1, F2, O1>
+{
+    /// Parse over a `FlatMap` structure
+    fn parse(&self, i1: DecodeBufIterator<'buf>) -> DCPResult<'buf, O2> {
+        let (i2, o1) = self.f1.parse(i1)?;
+        (self.f2)(o1).parse(i2)
+    }
+}
+
+/// Helper structure for `DecodeParser::and`.
+#[cfg(feature = "combinators")]
+pub struct And<F1, F2> {
+    f1: F1,
+    f2: F2,
+}
+
+#[cfg(feature = "combinators")]
+impl<'buf, O1, O2, F1: DecodeParser<'buf, O1>, F2: DecodeParser<'buf, O2>>
+    DecodeParser<'buf, (O1, O2)> for And<F1, F2>
+{
+    /// Parse over `And` structure
+    fn parse(&self, i1: DecodeBufIterator<'buf>) -> DCPResult<'buf, (O1, O2)> {
+        let (i2, o1) = self.f1.parse(i1)?;
+        let (i3, o2) = self.f2.parse(i2)?;
+        Ok((i3, (o1, o2)))
+    }
+}
+
+/// Helper structure for `DecodeParser::or`
+#[cfg(feature = "combinators")]
+pub struct Or<F1, F2> {
+    f1: F1,
+    f2: F2,
+}
+
+#[cfg(feature = "combinators")]
+impl<'buf, O, F1: DecodeParser<'buf, O>, F2: DecodeParser<'buf, O>> DecodeParser<'buf, O>
+    for Or<F1, F2>
+{
+    /// Parse over `Or` structure.
+    fn parse(&self, i: DecodeBufIterator<'buf>) -> DCPResult<'buf, O> {
+        match self.f1.parse(i.clone()) {
+            Err(_e1) => match self.f2.parse(i) {
+                Err(e2) => Err(e2),
+                res => res,
+            },
+            res => res,
+        }
+    }
+}
+
+/// Helper structure for `DecodeParser::into`.
+#[cfg(feature = "combinators")]
+pub struct Into<F, O1, O2: From<O1>> {
+    f: F,
+    phantom_o1: core::marker::PhantomData<O1>,
+    phantom_o2: core::marker::PhantomData<O2>,
+}
+
+#[cfg(feature = "combinators")]
+impl<'buf, O1, O2: From<O1>, F: DecodeParser<'buf, O1>> DecodeParser<'buf, O2> for Into<F, O1, O2> {
+    /// Parse over `Into` structure.
+    fn parse(&self, i: DecodeBufIterator<'buf>) -> DCPResult<'buf, O2> {
+        match self.f.parse(i) {
+            Ok((i2, o)) => Ok((i2, o.into())),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/***************************************************************************************************
+ * CBOR decoding combinators
+ **************************************************************************************************/
+
+/// Match any CBOR type
+#[cfg(feature = "combinators")]
+pub fn is_any<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(v) => Ok((iter, v)),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match the end of the CBOR decode buffer
+#[cfg(feature = "combinators")]
+pub fn is_eof<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(_) => Err(CBORError::EofExpected),
+            None => Ok((iter, CBOR::Eof)),
+        }
+    }
+}
+
+/// Match a CBOR positive integer
+#[cfg(feature = "combinators")]
+pub fn is_uint<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::UInt(_)) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("uint")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match a CBOR negative integer
+#[cfg(feature = "combinators")]
+pub fn is_nint<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::NInt(_)) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("nint")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match a CBOR integer
+#[cfg(feature = "combinators")]
+pub fn is_int<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |iter| DecodeParser::or(is_uint(), is_int()).parse(iter)
+}
+
+/// Match a CBOR bytestring
+#[cfg(feature = "combinators")]
+pub fn is_bstr<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::Bstr(_)) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("bstr")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match a CBOR bytestring
+#[cfg(feature = "combinators")]
+pub fn is_tstr<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::Tstr(_)) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("tstr")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match a CBOR `false` value
+#[cfg(feature = "combinators")]
+pub fn is_false<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::False) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("false")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match a CBOR `true` value
+#[cfg(feature = "combinators")]
+pub fn is_true<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::True) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("true")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match a CBOR `bool` value
+#[cfg(feature = "combinators")]
+pub fn is_bool<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::True) => Ok((iter, cbor)),
+            Some(cbor @ CBOR::False) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("bool")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match a CBOR `null` value
+#[cfg(feature = "combinators")]
+pub fn is_null<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::Null) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("null")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match a CBOR `undefined` value
+#[cfg(feature = "combinators")]
+pub fn is_undefined<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::Undefined) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("undefined")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match a CBOR `simple` value
+#[cfg(feature = "combinators")]
+pub fn is_simple<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::Simple(_)) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("simple")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match a CBOR array
+#[cfg(feature = "combinators")]
+pub fn is_array<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::Array(_)) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("array")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match a CBOR map
+#[cfg(feature = "combinators")]
+pub fn is_map<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::Map(_)) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("map")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match a CBOR tagget value
+#[cfg(feature = "combinators")]
+pub fn is_tag<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::Tag(_)) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("tag")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match a CBOR tag with a specific value
+#[cfg(feature = "combinators")]
+pub fn is_tag_with_value<'buf>(v: u64) -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::Tag(_)) => {
+                if let CBOR::Tag(tb) = cbor {
+                    if tb.get_tag() == v {
+                        Ok((iter, cbor))
+                    } else {
+                        Err(CBORError::ExpectedTag(v))
+                    }
+                } else {
+                    Err(CBORError::ExpectedTag(v))
+                }
+            }
+            Some(_) => Err(CBORError::ExpectedType("tag")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+#[cfg(all(feature = "combinators", feature = "std_tags"))]
+#[cfg_attr(feature = "trace", trace)]
+pub fn is_date_time<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    is_tag_helper(0, |iter: DecodeBufIterator| {
+        if let (_, CBOR::Tstr(date_time)) = is_tstr()(iter)? {
+            match chrono::DateTime::parse_from_rfc3339(date_time) {
+                Ok(dt) => Ok(CBOR::DateTime(dt)),
+                _ => Err(CBORError::BadDateTime),
+            }
+        } else {
+            Err(CBORError::ExpectedType("tstr"))
+        }
+    })
+}
+
+#[cfg(all(feature = "combinators", feature = "std_tags"))]
+#[cfg_attr(feature = "trace", trace)]
+pub fn is_epoch<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    is_tag_helper(1, |iter| {
+        let (_, cbor) = is_any()(iter)?;
+        match cbor {
+            CBOR::UInt(_) | CBOR::NInt(_) => Ok(CBOR::Epoch(cbor.try_into_i64()?)),
+            _ => Err(CBORError::ExpectedType("uint/nint")),
+        }
+    })
+}
+
+#[cfg(feature = "combinators")]
+#[cfg_attr(feature = "trace", trace)]
+fn is_tag_helper<'buf, F>(tag: u64, f: F) -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf>
+where
+    F: Fn(DecodeBufIterator<'buf>) -> Result<CBOR<'buf>, CBORError>,
+{
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(CBOR::Tag(tb)) => {
+                if tb.get_tag() == tag {
+                    Ok((iter, f(tb.into_iter())?))
+                } else {
+                    Err(CBORError::ExpectedTag(tag))
+                }
+            }
+            Some(_) => Err(CBORError::ExpectedType("tag")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/***************************************************************************************************
+ * Generic combinators (combinators over DecodeParser)
+ **************************************************************************************************/
+
+/// Conditionally execute a parser, returning the result in an `Option<CBOR>`
+#[cfg(feature = "combinators")]
+pub fn cond<'buf, O, F>(
+    b: bool,
+    f: F,
+) -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, Option<O>>
+where
+    F: DecodeParser<'buf, O>,
+{
+    move |input| {
+        if b {
+            match f.parse(input) {
+                Ok((i, o)) => Ok((i, Some(o))),
+                Err(e) => Err(e),
+            }
+        } else {
+            Ok((input, None))
+        }
+    }
+}
+
+// Continue to match a rule until the provided mutable slice is filled.
+
+/// Optionally match a rule, returning result in `Option<CBOR>`.
+#[cfg(feature = "combinators")]
+pub fn opt<'buf, O, F>(f: F) -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, Option<O>>
+where
+    F: DecodeParser<'buf, O>,
+{
+    move |i| match f.parse(i.clone()) {
+        Ok((i, o)) => Ok((i, Some(o))),
+        Err(_) => Ok((i, None)),
+    }
+}
+
+/// Match one of two rules, returning result in `Option<CBOR>`.
+#[cfg(feature = "combinators")]
+pub fn or<'buf, O, F>(
+    f1: F,
+    f2: F,
+) -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, Option<O>>
+where
+    F: DecodeParser<'buf, O>,
+{
+    move |i| {
+        let i1 = i.clone();
+        let i2 = i.clone();
+
+        let r1 = f1.parse(i1);
+        let r2 = f2.parse(i2);
+        match (r1, r2) {
+            (Ok((it1, o1)), _) => Ok((it1, Some(o1))),
+            (_, Ok((it2, o2))) => Ok((it2, Some(o2))),
+            (_, _) => Err(CBORError::FailedPredicate),
+        }
+    }
+}
+
+/// If a rule succeeds, apply a verification function to its output. The verification function
+/// should return `true` if verification succeeded.
+#[cfg(feature = "combinators")]
+pub fn with_pred<'buf, O, F>(
+    f: F,
+    g: impl Fn(&O) -> bool,
+) -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, O>
+where
+    F: DecodeParser<'buf, O>,
+{
+    move |i| {
+        let (i, o) = f.parse(i)?;
+        if g(&o) {
+            Ok((i, o))
+        } else {
+            Err(CBORError::FailedPredicate)
+        }
+    }
+}
+
+/// If a rule succeeds, unconditionally apply a function to its output and continue.
+///
+/// This combinator is particularly useful where side-effects from parsing success are desired.
+#[cfg(feature = "combinators")]
+pub fn apply<'buf, O, F>(
+    f: F,
+    g: impl Fn(&O) -> (),
+) -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, O>
+where
+    F: DecodeParser<'buf, O>,
+{
+    move |i| {
+        let (i, o) = f.parse(i)?;
+        g(&o);
+        Ok((i, o))
+    }
+}
+
+/// Succeeds if a value is matched.
+#[cfg(feature = "combinators")]
+pub fn with_value<'buf, O: PartialEq, F>(
+    f: F,
+    v: O,
+) -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, O>
+where
+    F: DecodeParser<'buf, O>,
+{
+    move |i| {
+        let (i, o) = f.parse(i)?;
+        if o == v {
+            Ok((i, o))
+        } else {
+            Err(CBORError::FailedPredicate)
+        }
+    }
+}

--- a/rs_minicbor/src/encode.rs
+++ b/rs_minicbor/src/encode.rs
@@ -1,0 +1,843 @@
+/***************************************************************************************************
+ * Copyright (c) 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * CBOR Encoder
+ *
+ * A fairly comprehensive, memory efficient, serializer for CBOR (RFC7049). This serializer
+ * is designed for use in constrained systems and requires neither the Rust standard library
+ * nor an allocator.
+ *
+ * There is an optional simplified serialization API which has a small memory cost. This can be
+ * disabled with the `embedded` profile option.
+ **************************************************************************************************/
+use crate::ast::CBOR;
+use crate::constants::*;
+use crate::decode::SequenceBuffer;
+use crate::error::CBORError;
+use crate::utils::within;
+
+#[cfg(feature = "std_tags")]
+use std::mem::size_of;
+
+#[cfg(feature = "float")]
+use half::f16;
+
+use crate::ast::CBOR::{NInt, Tstr, UInt};
+use chrono::{DateTime, FixedOffset};
+#[cfg(feature = "trace")]
+use func_trace::trace;
+use std::string::String;
+
+#[cfg(feature = "trace")]
+func_trace::init_depth_var!();
+
+// Private structure used when returning integer encodings to indicate that the Major Type has
+// not been set. The caller should consider whether this needs to be addressed
+#[derive(Debug, Clone)]
+struct MtUnset(usize);
+
+#[derive(Debug)]
+#[cfg(feature = "combinators")]
+pub struct CBOREncoder<'buf> {
+    pub(self) buf: EncodeBuffer<'buf>,
+}
+
+#[cfg(feature = "combinators")]
+impl<'buf> CBOREncoder<'buf> {
+    pub fn new(buf: &'buf mut [u8]) -> Self {
+        CBOREncoder {
+            buf: EncodeBuffer::new(buf),
+        }
+    }
+
+    /// Insert an `EncodeItem` item into an `EncodeBuffer`.
+    #[inline]
+    pub fn insert(&mut self, item: &dyn EncodeItem) -> Result<&mut Self, CBORError> {
+        self.buf.insert(item)?;
+        Ok(self)
+    }
+
+    #[inline]
+    pub fn insert_key_value(
+        &mut self,
+        key: &dyn EncodeItem,
+        value: &dyn EncodeItem,
+    ) -> Result<&mut Self, CBORError> {
+        self.buf.insert_key_value(key, value)?;
+        Ok(self)
+    }
+
+    #[inline]
+    pub fn encoded(&self) -> Result<&[u8], CBORError> {
+        self.buf.encoded()
+    }
+
+    /// Marker for the start of a CBOR Array structure, which must later be finalized with a call
+    /// to `finalize_array`.
+    ///
+    /// Information about the state of the buffer before the insertion of the Array is saved in an
+    /// opaque `Array` context structure which is used to store information required to fix up the
+    /// array length information once it is known.
+    ///
+    /// If the array is not finalized, the encoded CBOR representation will be incorrect.
+    #[inline]
+    pub fn array_start(&mut self, ctx: &mut EncodeContext) -> Result<&mut Self, CBORError> {
+        self.buf.array_start(ctx)?;
+        Ok(self)
+    }
+
+    /// Marker to finalize a CBOR Array structure once its contents have been inserted, using the
+    /// information in an `Array` context to complete the finalization depending on the number of
+    /// items inserted.
+    pub fn array_finalize(&mut self, ctx: &EncodeContext) -> Result<&mut Self, CBORError> {
+        self.buf.array_finalize(ctx)?;
+        Ok(self)
+    }
+
+    /// Marker for the start of a CBOR Array structure, which must later be finalized with a call
+    /// to `finalize_array`.
+    ///
+    /// Information about the state of the buffer before the insertion of the Array is saved in an
+    /// opaque `Array` context structure which is used to store information required to fix up the
+    /// array length information once it is known.
+    ///
+    /// If the array is not finalized, the encoded CBOR representation will be incorrect.
+    #[inline]
+    pub fn map_start(&mut self, ctx: &mut EncodeContext) -> Result<&mut Self, CBORError> {
+        self.buf.map_start(ctx)?;
+        Ok(self)
+    }
+
+    /// Marker to finalize a CBOR Array structure once its contents have been inserted, using the
+    /// information in an `Array` context to complete the finalization depending on the number of
+    /// items inserted.
+    #[inline]
+    pub fn map_finalize(&mut self, ctx: &EncodeContext) -> Result<&mut Self, CBORError> {
+        self.buf.map_finalize(ctx)?;
+        Ok(self)
+    }
+
+    /// Tag the next CBOR item. If there is no following item, the CBOR will be mal-formed.
+    pub fn tag_next_item(&mut self, tag: u64) -> Result<&mut Self, CBORError> {
+        let _ = self.buf.tag_next_item(tag)?;
+        Ok(self)
+    }
+
+    pub fn build(&'buf self) -> Result<SequenceBuffer<'buf>, CBORError> {
+        Ok(SequenceBuffer::new(self.buf.encoded()?))
+    }
+}
+
+/***************************************************************************************************
+ * Encode Buffer
+ **************************************************************************************************/
+
+#[derive(Debug)]
+#[cfg(feature = "combinators")]
+pub struct EncodeBuffer<'buf> {
+    bytes: &'buf mut [u8],
+    index: usize,
+    items: usize,
+}
+
+#[cfg(feature = "combinators")]
+impl<'buf, 'short> EncodeBuffer<'buf>
+where
+    'buf: 'short,
+{
+    /// Construct an instance of EncodeBuffer from a buffer.
+    ///
+    /// The buffer is cleared on each instantiation of `EncodeBuffer`. This allows the same
+    /// underlying mutable buffer to be re-used.
+    #[inline]
+    pub fn new(b: &'buf mut [u8]) -> EncodeBuffer<'buf> {
+        b.fill(0);
+        EncodeBuffer {
+            bytes: b,
+            index: 0,
+            items: 0,
+        }
+    }
+
+    /// Insert an `EncodeItem` item into an `EncodeBuffer`.
+    pub fn insert(&mut self, item: &dyn EncodeItem) -> Result<usize, CBORError> {
+        let size = item.encode(self)?;
+        self.items += 1;
+        Ok(size)
+    }
+
+    /// Insert a (key, value) pair of `EncodeItems` into an `EncodeBuffer`.
+    ///
+    /// This function is most likely to be useful when encoding CBOR maps, although it actually
+    /// is just a convenience function for calling `insert` twice in sequence.
+    pub fn insert_key_value(
+        &mut self,
+        key: &dyn EncodeItem,
+        value: &dyn EncodeItem,
+    ) -> Result<usize, CBORError> {
+        let s1 = self.insert(key)?;
+        let s2 = self.insert(value)?;
+        Ok(s1 + s2)
+    }
+
+    /// Tag the item that follows
+    pub fn tag_next_item(&mut self, tag: u64) -> Result<usize, CBORError> {
+        // Encode the tag
+        let tag_len = encode_unsigned(self, tag)?;
+        self.set_mt(MT_TAG);
+        self.update_index(tag_len.0 + 1)?;
+        Ok(tag_len.0)
+    }
+
+    pub fn array_start(&mut self, ctx: &mut EncodeContext) -> Result<&mut Self, CBORError> {
+        ctx.context_type = ContextType::Array;
+        self.context_start_common(ctx)
+    }
+
+    /// Marker to finalize a CBOR Array structure once its contents have been inserted, using the
+    /// information in an `Array` context to complete the finalization depending on the number of
+    /// items inserted.
+    pub fn array_finalize(&mut self, ctx: &EncodeContext) -> Result<&mut Self, CBORError> {
+        self.context_finalize_common(ctx)
+    }
+
+    /// Marker for the start of a CBOR Array structure, which must later be finalized with a call
+    /// to `finalize_array`.
+    ///
+    /// Information about the state of the buffer before the insertion of the Array is saved in an
+    /// opaque `Array` context structure which is used to store information required to fix up the
+    /// array length information once it is known.
+    ///
+    /// If the array is not finalized, the encoded CBOR representation will be incorrect.
+    #[inline]
+    pub fn map_start(&mut self, ctx: &mut EncodeContext) -> Result<&mut Self, CBORError> {
+        ctx.context_type = ContextType::Map;
+        self.context_start_common(ctx)
+    }
+
+    /// Marker to finalize a CBOR Array structure once its contents have been inserted, using the
+    /// information in an `Array` context to complete the finalization depending on the number of
+    /// items inserted.
+    #[inline]
+    pub fn map_finalize(&mut self, ctx: &EncodeContext) -> Result<&mut Self, CBORError> {
+        self.context_finalize_common(ctx)
+    }
+
+    /// Return a slice containing the encoded input.
+    ///
+    /// Will generate a buffer overflow error if the current encoding overflowed the buffer
+    //#[cfg_attr(feature = "trace", trace)]
+    pub fn encoded(&self) -> Result<&[u8], CBORError> {
+        if within(self.bytes, 0, self.index) {
+            Ok(self.bytes[0..self.index].as_ref())
+        } else {
+            Err(CBORError::EndOfBuffer)
+        }
+    }
+
+    /// Return `true` if `offset` is within the remaining space in the buffer (i.e. starting at
+    /// `index`.
+    #[cfg_attr(feature = "trace", trace)]
+    fn within(&'buf self, offset: usize) -> bool {
+        within(self.bytes, self.index, offset)
+    }
+
+    /// Update `index` with the number of bytes inserted
+    #[inline]
+    #[cfg_attr(feature = "trace", trace)]
+    fn update_index(&mut self, len: usize) -> Result<usize, CBORError> {
+        self.index += len;
+        Ok(len)
+    }
+
+    /// Set `index` to an absolute position within the buffer
+    #[inline]
+    #[cfg_attr(feature = "trace", trace)]
+    fn set_index_abs(&mut self, index: usize) {
+        self.index = index
+    }
+
+    /// Get the current value of `index`.
+    #[inline]
+    #[cfg_attr(feature = "trace", trace)]
+    fn get_index(&self) -> Result<usize, CBORError> {
+        if self.within(0) {
+            Ok(self.index)
+        } else {
+            Err(CBORError::EndOfBuffer)
+        }
+    }
+
+    /// Set the Major Type. Assumes that `index` is at the `MT/AI` byte.
+    #[inline]
+    #[cfg_attr(feature = "trace", trace)]
+    fn set_mt(&mut self, mt: u8) {
+        self.bytes[self.index] |= mt;
+    }
+
+    /// Write a byte at an `offset` from the current `index` where the Item being processed starts.
+    ///
+    /// Will generate a buffer overflow error if the write would overflow the buffer
+    #[cfg_attr(feature = "trace", trace)]
+    fn write_byte_at_offset(&mut self, offset: usize, val: u8) -> Result<(), CBORError> {
+        if within(self.bytes, self.index, offset) {
+            self.bytes[self.index + offset] = val;
+            Ok(())
+        } else {
+            Err(CBORError::EndOfBuffer)
+        }
+    }
+
+    /// Write values from `src` to an `offset` from the current `index` where the item being
+    /// processed starts.
+    ///
+    /// Will generate a buffer overflow error if the write would overflow the buffer
+    #[cfg_attr(feature = "trace", trace)]
+    fn write_slice_at_offset(&mut self, offset: usize, src: &[u8]) -> Result<(), CBORError> {
+        if within(self.bytes, self.index, offset + src.len()) {
+            self.bytes[self.index + offset..self.index + offset + src.len()].copy_from_slice(src);
+            Ok(())
+        } else {
+            Err(CBORError::EndOfBuffer)
+        }
+    }
+
+    /// Move items from `src_index` to `dst_index`, where `src_index` < `dest_index`.
+    #[cfg_attr(feature = "trace", trace)]
+    fn move_items(
+        &mut self,
+        src_index: usize,
+        dst_index: usize,
+        len: usize,
+    ) -> Result<(), CBORError> {
+        if src_index < dst_index {
+            if self.within(dst_index + len) {
+                for i in (0..len).rev() {
+                    self.bytes[dst_index + i] = self.bytes[src_index + i];
+                }
+                Ok(())
+            } else {
+                Err(CBORError::EndOfBuffer)
+            }
+        } else {
+            Err(CBORError::BadSliceLength)
+        }
+    }
+
+    fn context_start_common(&mut self, ctx: &mut EncodeContext) -> Result<&mut Self, CBORError> {
+        // Save the context of the start of the array
+        ctx.mt_ai_index = self.get_index()?;
+        ctx.no_of_items_before_ctx = self.items;
+        ctx.ctx_encode_start = ctx.mt_ai_index + 1;
+
+        // Update the buffer index to start to the next element after MT/AI. We may need to
+        // revisit this on finalization.
+        self.update_index(1)?;
+        Ok(self)
+    }
+
+    fn context_finalize_common(&mut self, ctx: &EncodeContext) -> Result<&mut Self, CBORError> {
+        // Determine what we put into the array
+        let context_encode_end = self.get_index()?;
+        let no_of_items_after_context_added = self.items;
+        let ctx_param_value = match ctx.context_type {
+            ContextType::Array => no_of_items_after_context_added - ctx.no_of_items_before_ctx,
+            ContextType::Map => (no_of_items_after_context_added - ctx.no_of_items_before_ctx) / 2,
+        };
+        let context_items_len_bytes = context_encode_end - ctx.ctx_encode_start;
+
+        // We need to check the size of encoding for the number of array items. If it is more than
+        // can fit on MT/AI byte, we will need to move the encoded array items to follow the encoded
+        // number of items. This is unfortunate, but it is consequence of not knowing number of
+        // items a-priori
+        let ctx_param_len = match ctx_param_value {
+            0..=23 => 0,
+            24..=0xff => 1,
+            0x100..=0xffff => 2,
+            0x10000..=0xffff_ffff => 4,
+            _ => 8,
+        };
+
+        if ctx_param_len > 0 {
+            // Move array items up by ctx_param_len
+            self.move_items(
+                ctx.ctx_encode_start,
+                ctx.ctx_encode_start + ctx_param_len,
+                context_items_len_bytes,
+            )?;
+        }
+
+        // Now can go back and encode array length and MT/AI byte
+        self.set_index_abs(ctx.mt_ai_index);
+        let _ = encode_unsigned(self, ctx_param_value as u64)?;
+
+        match ctx.context_type {
+            ContextType::Array => self.set_mt(MT_ARRAY),
+            ContextType::Map => self.set_mt(MT_MAP),
+        }
+        self.set_index_abs(context_encode_end);
+
+        // Final check on the encoded value rules before we return a value.
+        match ctx.context_type {
+            ContextType::Array => Ok(self),
+            ContextType::Map => {
+                if (no_of_items_after_context_added - ctx.no_of_items_before_ctx) % 2 == 0 {
+                    Ok(self)
+                } else {
+                    Err(CBORError::MalformedEncoding)
+                }
+            }
+        }
+    }
+}
+
+/***************************************************************************************************
+ * Encode Item
+ **************************************************************************************************/
+
+/// The `EncodeItem` trait encapsulates encoding operations as anything that can be serialized to
+/// CBOR.
+pub trait EncodeItem {
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError>;
+}
+
+#[cfg(feature = "std_tags")]
+impl<'buf> EncodeItem for CBOR<'buf> {
+    #[cfg_attr(feature = "trace", trace)]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        match *self {
+            CBOR::UInt(val) => (&val).encode(buf),
+            CBOR::NInt(val) => {
+                let signed_val: i128 = -1 - (val as i128);
+                (&signed_val).encode(buf)
+            }
+            CBOR::Float64(val) => (&val).encode(buf),
+            CBOR::Float32(val) => (&val).encode(buf),
+            CBOR::Float16(val) => (&val).encode(buf),
+            CBOR::Bstr(bs) => bs.encode(buf),
+            CBOR::Tstr(ts) => ts.encode(buf),
+            CBOR::Array(_) => Err(CBORError::NotImplemented),
+            CBOR::Map(_) => Err(CBORError::NotImplemented),
+            CBOR::Tag(_) => Err(CBORError::NotImplemented),
+            CBOR::Simple(v) => {
+                match v {
+                    // Values below are reserved for specific usage or are illegal
+                    20..=31 => Err(CBORError::MalformedEncoding),
+                    _ => encode_item_simple(buf, v),
+                }
+            }
+            CBOR::False => encode_item_simple(buf, 20),
+            CBOR::True => encode_item_simple(buf, 21),
+            CBOR::Null => encode_item_simple(buf, 22),
+            CBOR::Undefined => encode_item_simple(buf, 23),
+            CBOR::Eof => Err(CBORError::MalformedEncoding),
+            CBOR::DateTime(date_time) => encode_date_time(buf, &date_time),
+            CBOR::Epoch(secs_since_1970) => encode_epoch(buf, secs_since_1970),
+        }
+    }
+}
+
+#[cfg(all(feature = "float", not(feature = "std_tags")))]
+impl<'buf> EncodeItem for CBOR<'buf> {
+    #[cfg_attr(feature = "trace", trace)]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        match *self {
+            CBOR::UInt(val) => (&val).encode(buf),
+            CBOR::NInt(val) => {
+                let signed_val: i128 = -1 - (val as i128);
+                (&signed_val).encode(buf)
+            }
+            CBOR::Float64(val) => (&val).encode(buf),
+            CBOR::Float32(val) => (&val).encode(buf),
+            CBOR::Float16(val) => (&val).encode(buf),
+            CBOR::Bstr(bs) => bs.encode(buf),
+            CBOR::Tstr(ts) => ts.encode(buf),
+            CBOR::Array(_) => Err(CBORError::NotImplemented),
+            CBOR::Map(_) => Err(CBORError::NotImplemented),
+            CBOR::Tag(_) => Err(CBORError::NotImplemented),
+            CBOR::Simple(v) => {
+                match v {
+                    // Values below are reserved for specific usage or are illegal
+                    20..=31 => Err(CBORError::MalformedEncoding),
+                    _ => encode_item_simple(buf, v),
+                }
+            }
+            CBOR::False => encode_item_simple(buf, 20),
+            CBOR::True => encode_item_simple(buf, 21),
+            CBOR::Null => encode_item_simple(buf, 22),
+            CBOR::Undefined => encode_item_simple(buf, 23),
+            CBOR::Eof => Err(CBORError::MalformedEncoding),
+        }
+    }
+}
+
+#[cfg(not(feature = "float"))]
+impl<'buf> EncodeItem for CBOR<'buf> {
+    #[cfg_attr(feature = "trace", trace)]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        match *self {
+            CBOR::UInt(val) => (&val).encode(buf),
+            CBOR::NInt(val) => {
+                let signed_val: i128 = -1 - (val as i128);
+                (&signed_val).encode(buf)
+            }
+            CBOR::Bstr(bs) => bs.encode(buf),
+            CBOR::Tstr(ts) => ts.encode(buf),
+            CBOR::Array(_) => Err(CBORError::NotImplemented),
+            CBOR::Map(_) => Err(CBORError::NotImplemented),
+            CBOR::Tag(_) => Err(CBORError::NotImplemented),
+            CBOR::Simple(v) => {
+                match v {
+                    // Values below are reserved for specific usage or are illegal
+                    20..=31 => Err(CBORError::MalformedEncoding),
+                    _ => encode_item_simple(buf, v),
+                }
+            }
+            CBOR::False => encode_item_simple(buf, 20),
+            CBOR::True => encode_item_simple(buf, 21),
+            CBOR::Null => encode_item_simple(buf, 22),
+            CBOR::Undefined => encode_item_simple(buf, 23),
+            CBOR::Eof => Err(CBORError::MalformedEncoding),
+        }
+    }
+}
+
+impl EncodeItem for u64 {
+    /// Encode a `u64` value on a buffer.
+    ///
+    /// Value is serialized using the preferred (shortest) serialization as a Major Type 0.
+    #[inline]
+    #[cfg_attr(feature = "trace", trace)]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        let item_len = encode_unsigned(buf, *self)?;
+        buf.set_mt(MT_UINT);
+        buf.update_index(item_len.0 + 1)
+    }
+}
+
+impl EncodeItem for u32 {
+    /// Encode a `u32` value on a buffer
+    ///
+    /// Value is serialized using the preferred (shortest) serialization as a Major Type 0.
+    #[inline]
+    #[cfg_attr(feature = "trace", trace)]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        (*self as u64).encode(buf)
+    }
+}
+
+impl EncodeItem for u16 {
+    /// Encode a `u16` value on a buffer
+    #[inline]
+    #[cfg_attr(feature = "trace", trace)]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        (*self as u64).encode(buf)
+    }
+}
+
+impl EncodeItem for u8 {
+    /// Encode a `u8` value on a buffer
+    #[inline]
+    #[cfg_attr(feature = "trace", trace)]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        (*self as u64).encode(buf)
+    }
+}
+
+impl EncodeItem for i128 {
+    /// Encode a `i128` value on a buffer.
+    ///
+    /// Value is serialized using the preferred (shortest) serialization as a Major Type 0
+    /// or Major Type 1.
+    ///
+    /// Note that serialization of `i128` can fail out of range as it can hold values exceeding the
+    /// maxima and minima for 64 bit encoding in CBOR.
+    #[cfg_attr(feature = "trace", trace)]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        if *self < 0 {
+            let v = -1 - *self;
+            if v >= 0 && v <= u64::MAX as i128 {
+                // We cannot just encode as u64 because we need a different MT value
+                let item_len = encode_unsigned(buf, v as u64)?;
+                buf.set_mt(MT_NINT);
+                buf.update_index(item_len.0 + 1)
+            } else {
+                Err(CBORError::OutOfRange)
+            }
+        } else {
+            if *self >= 0 && *self <= u64::MAX as i128 {
+                (*self as u64).encode(buf)
+            } else {
+                Err(CBORError::OutOfRange)
+            }
+        }
+    }
+}
+
+impl EncodeItem for i64 {
+    /// Encode a `i64` value on a buffer.
+    ///
+    /// Value is serialized using the preferred (shortest) serialization as a Major Type 0.
+    #[inline]
+    #[cfg_attr(feature = "trace", trace)]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        if *self < 0 {
+            let v = -1 - *self;
+            let item_len = encode_unsigned(buf, v as u64)?;
+            buf.set_mt(MT_NINT);
+            buf.update_index(item_len.0 + 1)
+        } else {
+            let item_len = encode_unsigned(buf, *self as u64)?;
+            buf.set_mt(MT_UINT);
+            buf.update_index(item_len.0 + 1)
+        }
+    }
+}
+
+impl EncodeItem for i32 {
+    /// Encode a `i32` value on a buffer.
+    ///
+    /// Value is serialized using the preferred (shortest) serialization as a Major Type 0
+    /// or Major Type 1.
+    #[inline]
+    #[cfg_attr(feature = "trace", trace)]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        (*self as i64).encode(buf)
+    }
+}
+
+impl EncodeItem for i16 {
+    /// Encode a `i16` value on a buffer.
+    ///
+    /// Value is serialized using the preferred (shortest) serialization as a Major Type 0
+    /// or Major Type 1.
+    #[inline]
+    #[cfg_attr(feature = "trace", trace)]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        (*self as i64).encode(buf)
+    }
+}
+
+impl EncodeItem for i8 {
+    /// Encode a `i8` value on a buffer.
+    ///
+    /// Value is serialized using the preferred (shortest) serialization as a Major Type 0
+    /// or Major Type 1.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        (*self as i64).encode(buf)
+    }
+}
+
+impl EncodeItem for &str {
+    /// Encode an `&str` value onto a buffer.
+    #[cfg_attr(feature = "trace", trace)]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        // First encode the string length
+        let item_len = encode_unsigned(buf, self.len() as u64)?;
+        let len_bytes = item_len.0;
+
+        // Then encode the string
+        buf.write_slice_at_offset(1 + len_bytes, self.as_bytes())?;
+        let written_bytes = self.len() + len_bytes + 1;
+        buf.set_mt(MT_TSTR);
+        buf.update_index(written_bytes)
+    }
+}
+
+impl EncodeItem for &[u8] {
+    /// Encode an `&[u8]` value onto a buffer.
+    #[cfg_attr(feature = "trace", trace)]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        // First encode the string length
+        let item_len = encode_unsigned(buf, self.len() as u64)?;
+        let len_bytes = item_len.0;
+
+        // Then encode the byte string
+        buf.write_slice_at_offset(1 + len_bytes, self)?;
+        let written_bytes = self.len() + len_bytes + 1;
+        buf.set_mt(MT_BSTR);
+        buf.update_index(written_bytes)
+    }
+}
+
+#[cfg(feature = "float")]
+impl EncodeItem for f64 {
+    /// Encode an `f64` value on a buffer.
+    ///
+    /// Value is serialized using the preferred (shortest) serialization as a Major Type 0
+    /// or Major Type 1.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        buf.write_byte_at_offset(0, PAYLOAD_EIGHT_BYTES)?;
+        buf.write_slice_at_offset(1, &(self.to_be_bytes()))?;
+        let written_bytes = 1 + size_of::<f64>();
+        buf.set_mt(MT_FLOAT);
+        buf.update_index(written_bytes)
+    }
+}
+
+#[cfg(feature = "float")]
+impl EncodeItem for f32 {
+    /// Encode an `f32` value on a buffer.
+    ///
+    /// Value is serialized using the preferred (shortest) serialization as a Major Type 0
+    /// or Major Type 1.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        buf.write_byte_at_offset(0, PAYLOAD_FOUR_BYTES)?;
+        buf.write_slice_at_offset(1, &(self.to_be_bytes()))?;
+        let written_bytes = 1 + size_of::<f32>();
+        buf.set_mt(MT_FLOAT);
+        buf.update_index(written_bytes)
+    }
+}
+
+#[cfg(feature = "float")]
+impl EncodeItem for f16 {
+    /// Encode an `f16` value on a buffer.
+    ///
+    /// Value is serialized using the preferred (shortest) serialization as a Major Type 0
+    /// or Major Type 1.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    fn encode(&self, buf: &mut EncodeBuffer) -> Result<usize, CBORError> {
+        buf.write_byte_at_offset(0, PAYLOAD_TWO_BYTES)?;
+        buf.write_slice_at_offset(1, &(self.to_be_bytes()))?;
+        let written_bytes = 1 + size_of::<f16>();
+        buf.set_mt(MT_FLOAT);
+        buf.update_index(written_bytes)
+    }
+}
+
+/***************************************************************************************************
+ * Encoding context for Array, Map
+ **************************************************************************************************/
+pub enum ContextType {
+    Array,
+    Map,
+}
+
+/// The `EncodeContext` structure encodes the information needed to encode a sequence of
+/// `EncodeItem`s on an `EncodeBuffer` and fix up the composite MT/AI/Length information.
+pub struct EncodeContext {
+    pub(self) context_type: ContextType,
+    pub(self) no_of_items_before_ctx: usize, // Number of items in buffer before the array starts
+    pub(self) mt_ai_index: usize,            // Index in buffer of the MT/AI for the array
+    pub(self) ctx_encode_start: usize,       // Index
+}
+
+impl EncodeContext {
+    /// Construct a new context structure which can later be used in a start/finalize context pair
+    /// of function calls.
+    pub fn new() -> Self {
+        EncodeContext {
+            context_type: ContextType::Array,
+            no_of_items_before_ctx: 0,
+            mt_ai_index: 0,
+            ctx_encode_start: 0,
+        }
+    }
+}
+
+/***************************************************************************************************
+ * Private helper functions
+ **************************************************************************************************/
+
+#[inline]
+#[cfg_attr(feature = "trace", trace)]
+fn encode_item_simple(buf: &mut EncodeBuffer, v: u8) -> Result<usize, CBORError> {
+    encode_unsigned(buf, v as u64)?;
+    match v {
+        24..=31 => return Err(CBORError::MalformedEncoding),
+        _ => buf.set_mt(MT_SIMPLE),
+    }
+    if v < 32 {
+        // Encoded on one byte
+        buf.update_index(1)
+    } else {
+        // Encoded on two bytes
+        buf.update_index(2)
+    }
+}
+
+/// Encode an unsigned integer value on `buf` starting at `start_index`.
+///
+/// Integer values are always encoded using preferred serialization as defined in RFC8949.
+/// The index just after the serialized value is returned if serialization was successful.
+/// `Err(CBORError::EndOfBuffer` is returned if there is no space for serialization.
+///
+/// The caller is expected to set the Major Type, if required, after the function returns.
+#[cfg_attr(feature = "trace", trace)]
+fn encode_unsigned(buf: &mut EncodeBuffer, v: u64) -> Result<MtUnset, CBORError> {
+    let vs = v.to_be_bytes();
+    if v < 24 {
+        // Encode on the AI bits
+        buf.write_byte_at_offset(0, vs[7])?;
+        Ok(MtUnset(0))
+    } else if v <= u8::MAX as u64 {
+        buf.write_byte_at_offset(0, PAYLOAD_ONE_BYTE)?;
+        buf.write_byte_at_offset(1, vs[7])?;
+        Ok(MtUnset(1))
+    } else if v <= u16::MAX as u64 {
+        buf.write_byte_at_offset(0, PAYLOAD_TWO_BYTES)?;
+        buf.write_slice_at_offset(1, &vs[6..=7])?;
+        Ok(MtUnset(2))
+    } else if v <= u32::MAX as u64 {
+        buf.write_byte_at_offset(0, PAYLOAD_FOUR_BYTES)?;
+        buf.write_slice_at_offset(1, &vs[4..=7])?;
+        Ok(MtUnset(4))
+    } else {
+        buf.write_byte_at_offset(0, PAYLOAD_EIGHT_BYTES)?;
+        buf.write_slice_at_offset(1, &vs[0..=7])?;
+        Ok(MtUnset(8))
+    }
+}
+
+/// Encode a `DateTime<FixedOffset>` on `buf`, starting at the (internal) `start_index`.
+/// The index just after the serialized value is returned if serialization was successful.
+/// `Err(CBORError::EndOfBuffer` is returned if there is no space for serialization.
+#[cfg(feature = "std_tags")]
+fn encode_date_time(
+    buf: &mut EncodeBuffer,
+    date: &DateTime<FixedOffset>,
+) -> Result<usize, CBORError> {
+    let date_string: String = date.to_rfc3339();
+    let tag_len = buf.tag_next_item(0)?;
+    let val_len = buf.insert(&Tstr(date_string.as_str()))?;
+    Ok(tag_len + val_len)
+}
+
+/// Encode a `DateTime<FixedOffset>` on `buf`, starting at the (internal) `start_index`.
+/// The index just after the serialized value is returned if serialization was successful.
+/// `Err(CBORError::EndOfBuffer` is returned if there is no space for serialization.
+#[cfg(feature = "std_tags")]
+fn encode_epoch(buf: &mut EncodeBuffer, secs: i64) -> Result<usize, CBORError> {
+    let tag_len = buf.tag_next_item(1)?;
+    let val_len = if secs < 0 {
+        let neg_secs = (-1 - secs) as u64;
+        buf.insert(&NInt(neg_secs))?
+    } else {
+        buf.insert(&UInt(secs as u64))?
+    };
+    Ok(tag_len + val_len)
+}

--- a/rs_minicbor/src/error.rs
+++ b/rs_minicbor/src/error.rs
@@ -1,0 +1,106 @@
+/***************************************************************************************************
+ * Copyright (c) 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * rs_minicbor CBOR ErrorAPI
+ *
+ * A fairly comprehensive, memory efficient, deserializer and serializer for CBOR (RFC7049).
+ * This implementation is designed for use in constrained systems and requires neither the Rust
+ * standard library nor an allocator.
+ **************************************************************************************************/
+use std::result;
+
+#[cfg(any(feature = "std", test))]
+use thiserror::Error;
+
+pub type Result<T> = result::Result<T, CBORError>;
+
+/// `CBORError` provides information about errors converting CBOR types to/from other types
+#[cfg_attr(any(feature = "std", test), derive(Copy, Clone, Error, Debug))]
+#[cfg_attr(all(not(feature = "std"), not(test)), derive(Copy, Clone, Debug))]
+pub enum CBORError {
+    #[cfg_attr(
+        any(feature = "std", test),
+        error("Overflow or underflow in number conversion")
+    )]
+    OutOfRange,
+    #[cfg_attr(
+        any(feature = "std", test),
+        error("Attempt to convert an item of incompatible type")
+    )]
+    IncompatibleType,
+    #[cfg_attr(
+        any(feature = "std", test),
+        error("Slice length is incompatible with the target type conversion")
+    )]
+    BadSliceLength,
+    #[cfg_attr(
+        any(feature = "std", test),
+        error("Buffer insufficient to process the next item")
+    )]
+    EndOfBuffer,
+    #[cfg_attr(
+        any(feature = "std", test),
+        error("A tstr contains an invalid UTF8 sequence")
+    )]
+    UTF8Error,
+    #[cfg_attr(
+        any(feature = "std", test),
+        error("The item was not expecting this AI encoding. Probably malformed")
+    )]
+    AIError,
+    #[cfg_attr(
+        any(feature = "std", test),
+        error("Encoding is illegal or unsupported")
+    )]
+    MalformedEncoding,
+    #[cfg_attr(
+        any(feature = "std", test),
+        error("The protocol feature is not supported")
+    )]
+    NotImplemented,
+    #[cfg_attr(
+        any(feature = "std", test),
+        error("No next item possible as end of buffer - this is usually recoverable")
+    )]
+    NoMoreItems(usize),
+    #[cfg_attr(any(feature = "std", test), error("Expected EOF"))]
+    EofExpected,
+    #[cfg_attr(any(feature = "std", test), error("Did not match expected CBOR type"))]
+    ExpectedType(&'static str),
+    #[cfg_attr(any(feature = "std", test), error("Failed predicate"))]
+    FailedPredicate,
+    #[cfg_attr(any(feature = "std", test), error("Unexpected Tag"))]
+    ExpectedTag(u64),
+    #[cfg_attr(
+        any(feature = "std", test),
+        error("Map does not contain the requested key")
+    )]
+    KeyNotPresent,
+    #[cfg_attr(
+        any(feature = "std", test),
+        error("Map does not contain a value for the found key")
+    )]
+    ValueNotPresent,
+    #[cfg_attr(any(feature = "std", test), error("Range underflow"))]
+    RangeUnderflow(usize),
+    #[cfg_attr(any(feature = "std", test), error("Bad Date/Time value"))]
+    BadDateTime,
+    #[cfg_attr(any(feature = "std", test), error("Type not allowed here"))]
+    NotAllowed,
+}

--- a/rs_minicbor/src/lib.rs
+++ b/rs_minicbor/src/lib.rs
@@ -1,0 +1,92 @@
+/***************************************************************************************************
+ * Copyright (c) 2020, 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * rs_minicbor module definition
+ *
+ * A fairly comprehensive, memory efficient, deserializer and serializer for CBOR (RFC8949).
+ * This implementation is designed for use in constrained systems and requires neither the Rust
+ * standard library nor an allocator.
+ **************************************************************************************************/
+// Default configuration
+#![no_std]
+/**
+RS-MINICBOR: a small implementation of CBOR (RFC8949) which can be configured for bare-metal
+embedded systems.
+ */
+
+// Pull in std if we are testing or if it is defined as feature (because we run tests on a
+// platform supporting I/O and full feature set.
+#[cfg(any(feature = "std", test))]
+extern crate std;
+
+// If we are really building no_std, pull in core as well. It is aliased as std so that "use"
+// statements are always the same
+#[cfg(all(not(feature = "std"), not(test)))]
+extern crate core as std;
+
+#[cfg(any(feature = "float", test))]
+extern crate half;
+
+#[cfg(any(feature = "std_tags", test))]
+extern crate chrono;
+
+pub(crate) mod array;
+pub(crate) mod ast;
+pub(crate) mod constants;
+pub(crate) mod decode;
+pub(crate) mod decode_combinators;
+pub(crate) mod encode;
+pub(crate) mod map;
+pub(crate) mod tag;
+pub(crate) mod utils;
+
+pub mod error;
+
+pub mod types {
+    pub use super::ast::CBOR;
+}
+
+pub mod decoder {
+    // Low-level API
+    pub use super::array::ArrayBuf;
+    pub use super::decode::{DecodeBufIterator, SequenceBuffer};
+    pub use super::map::MapBuf;
+    pub use super::tag::TagBuf;
+
+    // Decode Combinators API
+    #[cfg(any(feature = "combinators", test))]
+    pub use super::decode_combinators::{
+        apply, cond, is_any, is_array, is_bool, is_bstr, is_eof, is_false, is_int, is_map, is_nint,
+        is_null, is_simple, is_tag, is_tag_with_value, is_true, is_tstr, is_uint, is_undefined,
+        opt, or, with_pred, with_value, CBORDecoder,
+    };
+
+    #[cfg(any(feature = "combinators", test))]
+    pub use super::utils::{Allowable, Filter};
+
+    #[cfg(any(feature = "combinators", test))]
+    pub use super::constants::allow::*;
+
+    #[cfg(any(feature = "std_tags", test))]
+    pub use super::decode_combinators::{is_date_time, is_epoch};
+}
+
+pub mod encoder {
+    pub use super::encode::{CBOREncoder, EncodeBuffer, EncodeContext, EncodeItem};
+}

--- a/rs_minicbor/src/map.rs
+++ b/rs_minicbor/src/map.rs
@@ -1,0 +1,199 @@
+/***************************************************************************************************
+ * Copyright (c) 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * rs_minicbor CBOR Map deserialser API
+ *
+ * A fairly comprehensive, memory efficient, deserializer and serializer for CBOR (RFC7049).
+ * This implementation is designed for use in constrained systems and requires neither the Rust
+ * standard library nor an allocator.
+ **************************************************************************************************/
+use crate::ast::CBOR;
+use crate::decode::{DecodeBufIterator, DecodeBufIteratorSource};
+use crate::error::CBORError;
+
+#[cfg(feature = "trace")]
+use func_trace::trace;
+
+#[cfg(feature = "trace")]
+func_trace::init_depth_var!();
+
+/// A buffer which contains a CBOR Map to be decoded. The buffer has lifetime `'buf`,
+/// which must be longer than any borrow from the buffer itself. This is generally used to represent
+/// a CBOR map with an exposed map-like API.
+///
+/// This CBOR buffer implementation does not support indefinite length items.
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub struct MapBuf<'buf> {
+    bytes: &'buf [u8],
+    n_pairs: usize,
+}
+
+impl<'buf> MapBuf<'buf> {
+    /// Construct a new instance of `ArrayBuf` with all context initialized.
+    #[cfg_attr(feature = "trace", trace)]
+    pub fn new(init: &'buf [u8], n_pairs: usize) -> MapBuf<'buf> {
+        MapBuf {
+            bytes: init,
+            n_pairs,
+        }
+    }
+
+    /// Return the number of item pairs in the `MapBuf`.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn len(self) -> usize {
+        self.n_pairs
+    }
+
+    /// Return `true` if `MapBuf` is empty.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn is_empty(self) -> bool {
+        self.n_pairs == 0 && self.bytes.len() == 0
+    }
+
+    /// Return `true` if `MapBuf` contains the provided key
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn contains_key(self, key: &CBOR) -> bool {
+        match self.find_key_with_value(key) {
+            Ok((_, _)) => true,
+            _ => false,
+        }
+    }
+
+    /// Return the value corresponding to key.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn get(self, key: &CBOR) -> Option<CBOR<'buf>> {
+        match self.find_key_with_value(key) {
+            Ok((_, value)) => value,
+            _ => None,
+        }
+    }
+
+    /// Return the value corresponding to an integer key.
+    ///
+    /// In general, integers and strings are the recommended types to be used for map keys, so it
+    /// makes sense to simplify this use-case.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn get_int(self, v: i64) -> Option<CBOR<'buf>> {
+        self.get(&CBOR::from_i64(v))
+    }
+
+    /// Return the value corresponding to an integer key.
+    ///
+    /// In general, integers and strings are the recommended types to be used for map keys, so it
+    /// makes sense to simplify this use-case.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn get_tstr(self, v: &str) -> Option<CBOR<'buf>> {
+        self.get(&CBOR::from_str(v))
+    }
+
+    /// Return value corresponding to a map item that can have either an integer or a string
+    /// key. This is a common use-case in IETF standards where human readability vs compactness
+    /// tradeoff is supported.
+    ///
+    /// In general, integers and strings are the recommended types to be used for map keys, so it
+    /// makes sense to simplify this use-case.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn get_int_or_tstr(self, v: i64, s: &str) -> Option<CBOR<'buf>> {
+        if let Some(cbor) = self.get_int(v) {
+            Some(cbor)
+        } else {
+            self.get_tstr(s)
+        }
+    }
+
+    /// Return the key, value pair corresponding to key.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn get_key_value(self, key: &CBOR) -> Option<(CBOR<'buf>, CBOR<'buf>)> {
+        match self.find_key_with_value(key) {
+            Ok((found_key, Some(found_value))) => Some((found_key, found_value)),
+            _ => None,
+        }
+    }
+
+    /// Return the (key, value) pair corresponding to an integer used as a key
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn get_int_key_value(self, key: i64) -> Option<(CBOR<'buf>, CBOR<'buf>)> {
+        self.get_key_value(&CBOR::from_i64(key))
+    }
+
+    /// Return the (key, value) pair corresponding to an tstr used as a key
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn get_tstr_key_value(self, key: &str) -> Option<(CBOR<'buf>, CBOR<'buf>)> {
+        self.get_key_value(&CBOR::from_str(key))
+    }
+
+    /// Return (key, value) pair  corresponding to a map item that can have either an integer or a
+    /// string key. This is a common use-case in IETF standards where human readability vs
+    /// compactness tradeoff is supported.
+    #[cfg_attr(feature = "trace", trace)]
+    #[inline]
+    pub fn get_int_or_tstr_key_value(self, v: i64, s: &str) -> Option<(CBOR<'buf>, CBOR<'buf>)> {
+        if let Some(pair) = self.get_int_key_value(v) {
+            Some(pair)
+        } else {
+            self.get_tstr_key_value(s)
+        }
+    }
+
+    /// (private) If there is a key matching `search_key`, return the
+    /// key and corresponding value, otherwise return a `KeyNotPresent` error.
+    #[cfg_attr(feature = "trace", trace)]
+    fn find_key_with_value(
+        self,
+        search_key: &CBOR,
+    ) -> Result<(CBOR<'buf>, Option<CBOR<'buf>>), CBORError> {
+        let mut it: DecodeBufIterator<'buf> = self.into_iter();
+        let mut current_key = it.next();
+        while current_key.is_some() {
+            if let Some(item_key) = current_key {
+                if item_key == *search_key {
+                    return Ok((item_key, it.next()));
+                }
+                let _ = it.next(); // skip the next value as it doesn't match key
+                current_key = it.next(); // This one is a key again
+            }
+        }
+        return Err(CBORError::KeyNotPresent);
+    }
+}
+
+impl<'buf> IntoIterator for MapBuf<'buf> {
+    type Item = CBOR<'buf>;
+    type IntoIter = DecodeBufIterator<'buf>;
+
+    /// Construct an Iterator adapter from a `DecodeBuf`.
+    #[cfg_attr(feature = "trace", trace)]
+    fn into_iter(self) -> Self::IntoIter {
+        DecodeBufIterator {
+            buf: self.bytes,
+            index: 0,
+            source: DecodeBufIteratorSource::Map,
+        }
+    }
+}

--- a/rs_minicbor/src/tag.rs
+++ b/rs_minicbor/src/tag.rs
@@ -1,0 +1,74 @@
+/***************************************************************************************************
+ * Copyright (c) 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * rs_minicbor CBOR Tag deserialser API
+ *
+ * A fairly comprehensive, memory efficient, deserializer and serializer for CBOR (RFC7049).
+ * This implementation is designed for use in constrained systems and requires neither the Rust
+ * standard library nor an allocator.
+ **************************************************************************************************/
+use crate::ast::CBOR;
+use crate::decode::{DecodeBufIterator, DecodeBufIteratorSource};
+
+#[cfg(feature = "trace")]
+use func_trace::trace;
+
+#[cfg(feature = "trace")]
+func_trace::init_depth_var!();
+
+/// A buffer which contains a tagged item to be decoded. The buffer has lifetime `'buf`,
+/// which must be longer than any borrow from the buffer itself. This is generally used to represent
+/// a CBOR map with an exposed map-like API.
+///
+/// This CBOR buffer implementation does not support indefinite length items.
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub struct TagBuf<'buf> {
+    tag: u64,
+    bytes: &'buf [u8],
+}
+
+impl<'buf> TagBuf<'buf> {
+    /// Construct a new instance of `TagBuf` with all context initialized.
+    #[cfg_attr(feature = "trace", trace)]
+    pub fn new(init: &'buf [u8], tag: u64) -> TagBuf<'buf> {
+        TagBuf { bytes: init, tag }
+    }
+
+    /// Get the tag value for this instance of `TagBuf`.
+    #[inline]
+    #[cfg_attr(feature = "trace", trace)]
+    pub fn get_tag(&self) -> u64 {
+        self.tag
+    }
+}
+
+impl<'buf> IntoIterator for TagBuf<'buf> {
+    type Item = CBOR<'buf>;
+    type IntoIter = DecodeBufIterator<'buf>;
+
+    /// Construct an Iterator adapter from a `DecodeBuf`.
+    #[cfg_attr(feature = "trace", trace)]
+    fn into_iter(self) -> Self::IntoIter {
+        DecodeBufIterator {
+            buf: self.bytes,
+            index: 0,
+            source: DecodeBufIteratorSource::Tag,
+        }
+    }
+}

--- a/rs_minicbor/src/utils.rs
+++ b/rs_minicbor/src/utils.rs
@@ -1,0 +1,201 @@
+/***************************************************************************************************
+ * Copyright (c) 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * rs_minicbor CBOR utilities API
+ *
+ * A fairly comprehensive, memory efficient, deserializer and serializer for CBOR (RFC7049).
+ * This implementation is designed for use in constrained systems and requires neither the Rust
+ * standard library nor an allocator.
+ **************************************************************************************************/
+use crate::constants::allow;
+#[cfg(feature = "trace")]
+use func_trace::trace;
+
+use crate::ast::CBOR;
+use crate::error::CBORError;
+
+#[cfg(feature = "trace")]
+func_trace::init_depth_var!();
+
+/// Return `true` if it is possible to obtain a slice of length `len` starting from `start` from
+/// `buf`
+#[cfg_attr(feature = "trace", trace)]
+#[inline]
+pub fn within(buf: &[u8], start: usize, len: usize) -> bool {
+    start + len <= buf.len()
+}
+
+#[cfg(feature = "combinators")]
+#[derive(Debug, Copy, Clone)]
+pub struct Allowable(u32);
+
+#[cfg(feature = "combinators")]
+impl Allowable {
+    pub fn new(v: u32) -> Self {
+        Allowable(v)
+    }
+
+    pub fn allow_none(&self) -> bool {
+        self.0 & allow::NONE != 0
+    }
+
+    pub fn allow_uint(&self) -> bool {
+        self.0 & allow::UINT != 0
+    }
+
+    pub fn allow_nint(&self) -> bool {
+        self.0 & allow::NINT != 0
+    }
+
+    pub fn allow_bstr(&self) -> bool {
+        self.0 & allow::BSTR != 0
+    }
+
+    pub fn allow_tstr(&self) -> bool {
+        self.0 & allow::TSTR != 0
+    }
+
+    pub fn allow_array(&self) -> bool {
+        self.0 & allow::ARRAY != 0
+    }
+
+    pub fn allow_map(&self) -> bool {
+        self.0 & allow::MAP != 0
+    }
+
+    pub fn allow_tag(&self) -> bool {
+        self.0 & allow::TAG != 0
+    }
+
+    pub fn allow_simple(&self) -> bool {
+        self.0 & allow::SIMPLE != 0
+    }
+
+    pub fn allow_float(&self) -> bool {
+        self.0 & allow::FLOAT != 0
+    }
+}
+
+#[cfg(feature = "combinators")]
+pub trait Filter {
+    type Error;
+
+    fn allow(self, allow: Allowable) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+}
+
+#[cfg(feature = "combinators")]
+impl<'buf> Filter for Option<CBOR<'buf>> {
+    type Error = CBORError;
+
+    fn allow(self, allow: Allowable) -> Result<Option<CBOR<'buf>>, Self::Error> {
+        match self {
+            Some(cbor) => {
+                let result = cbor.allow(allow);
+                if result.is_ok() {
+                    Ok(self)
+                } else {
+                    Err(CBORError::NotAllowed)
+                }
+            }
+            None => {
+                if allow.allow_none() {
+                    Ok(self)
+                } else {
+                    Err(CBORError::NotAllowed)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "combinators")]
+impl<'buf> Filter for CBOR<'buf> {
+    type Error = CBORError;
+
+    fn allow(self, allow: Allowable) -> Result<CBOR<'buf>, Self::Error> {
+        match self {
+            CBOR::UInt(_) => {
+                if allow.allow_uint() {
+                    Ok(self)
+                } else {
+                    Err(CBORError::NotAllowed)
+                }
+            }
+            CBOR::NInt(_) => {
+                if allow.allow_nint() {
+                    Ok(self)
+                } else {
+                    Err(CBORError::NotAllowed)
+                }
+            }
+            CBOR::Bstr(_) => {
+                if allow.allow_bstr() {
+                    Ok(self)
+                } else {
+                    Err(CBORError::NotAllowed)
+                }
+            }
+            CBOR::Tstr(_) => {
+                if allow.allow_tstr() {
+                    Ok(self)
+                } else {
+                    Err(CBORError::NotAllowed)
+                }
+            }
+            CBOR::Array(_) => {
+                if allow.allow_array() {
+                    Ok(self)
+                } else {
+                    Err(CBORError::NotAllowed)
+                }
+            }
+            CBOR::Map(_) => {
+                if allow.allow_map() {
+                    Ok(self)
+                } else {
+                    Err(CBORError::NotAllowed)
+                }
+            }
+            CBOR::Tag(_) => {
+                if allow.allow_tag() {
+                    Ok(self)
+                } else {
+                    Err(CBORError::NotAllowed)
+                }
+            }
+            CBOR::Simple(_) | CBOR::True | CBOR::False | CBOR::Null | CBOR::Undefined => {
+                if allow.allow_simple() {
+                    Ok(self)
+                } else {
+                    Err(CBORError::NotAllowed)
+                }
+            }
+            CBOR::Float64(_) | CBOR::Float32(_) | CBOR::Float16(_) => {
+                if allow.allow_float() {
+                    Ok(self)
+                } else {
+                    Err(CBORError::NotAllowed)
+                }
+            }
+            _ => Err(CBORError::NotAllowed),
+        }
+    }
+}

--- a/rs_minicbor/tests/decoder.rs
+++ b/rs_minicbor/tests/decoder.rs
@@ -1,0 +1,1128 @@
+/***************************************************************************************************
+ * Copyright (c) 2020, 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * Test cases from RFC7049, for decoding
+ *
+ * Test cases from RFC7049, Table 4.
+ **************************************************************************************************/
+
+extern crate rs_minicbor;
+
+use core::convert::TryFrom;
+use half::f16;
+
+use rs_minicbor::decoder::*;
+use rs_minicbor::error::CBORError;
+use rs_minicbor::types::CBOR;
+
+macro_rules! check_int_result {
+    ($result:expr, $expected:expr) => {
+        if let Ok(value) = $result {
+            if let Some(expected_value) = $expected {
+                // Have value, expect value
+                println!("value: {:?}, expected: {:?}", value, expected_value);
+                assert_eq!(value as i128, expected_value)
+            } else {
+                // No value, expect value
+                println!("value {:?}, expected {:?}", value, $expected);
+                assert!(false)
+            }
+        } else {
+            if $expected.is_some() {
+                // Have value, not expected
+                assert!(false)
+            } else {
+                // No value, none expected
+                assert!(true)
+            }
+        }
+    };
+}
+
+fn decode_single(buf: &[u8]) -> Option<CBOR> {
+    let b = SequenceBuffer::new(buf);
+    let mut it = b.into_iter();
+    it.next()
+}
+
+// Check that integer values are decoded into the expected values by all of the parsers, and that
+// over/underflows are properly detected.
+fn decode_integer(buf: &[u8], expected_values: &[Option<i128>; 9]) {
+    if let Some(item) = decode_single(buf) {
+        let u1 = u8::try_from(&item);
+        let u2 = u16::try_from(&item);
+        let u3 = u32::try_from(&item);
+        let u4 = u64::try_from(&item);
+        let s1 = i8::try_from(&item);
+        let s2 = i16::try_from(&item);
+        let s3 = i32::try_from(&item);
+        let s4 = i64::try_from(&item);
+        let s5 = i128::try_from(&item);
+
+        check_int_result!(u1, expected_values[0]);
+        check_int_result!(u2, expected_values[1]);
+        check_int_result!(u3, expected_values[2]);
+        check_int_result!(u4, expected_values[3]);
+        check_int_result!(s1, expected_values[4]);
+        check_int_result!(s2, expected_values[5]);
+        check_int_result!(s3, expected_values[6]);
+        check_int_result!(s4, expected_values[7]);
+        check_int_result!(s5, expected_values[8]);
+    } else {
+        assert!(false)
+    }
+}
+
+// Check that bstr values are decoded into the expected values
+fn decode_bstr(buf: &[u8], expect: &[u8]) {
+    if let Some(item) = decode_single(buf) {
+        if let CBOR::Bstr(slice) = item {
+            let result: &[u8] = slice.into();
+            assert_eq!(expect, result);
+        } else {
+            assert!(false);
+        }
+    }
+}
+
+// Check that str values are decoded into the expected values
+fn decode_str(buf: &[u8], expect: &str) {
+    if let Some(item) = decode_single(buf) {
+        if let CBOR::Tstr(s) = item {
+            let result: &str = s.into();
+            assert_eq!(expect, result);
+        } else {
+            assert!(false);
+        }
+    }
+}
+
+// Check the content of an array containing integer values is as expected. We convert everything
+// to i128 so that we can test over all integer values
+fn decode_integer_array(buf: &[u8], expect: &[i128]) {
+    if let Some(CBOR::Array(ab)) = decode_single(&buf) {
+        let mut result: Vec<i128> = Vec::new();
+        for item in ab.into_iter() {
+            match item {
+                CBOR::UInt(_) => {
+                    if let Ok(value) = i128::try_from(&item) {
+                        result.push(value)
+                    }
+                }
+                CBOR::NInt(_) => {
+                    if let Ok(value) = i128::try_from(&item) {
+                        result.push(value)
+                    }
+                }
+                _ => (),
+            }
+        }
+        assert_eq!(&result, expect);
+    } else {
+        // If we don't have an array when we expect one, it's obviously a failure
+        assert!(false)
+    }
+}
+
+// Verify unsigned integer item decode using iterator API and <type>::try_from(&item) for all cases
+#[test]
+fn rfc8949_decode_uint_manual() {
+    println!("<======================= rfc8949_decode_uint =====================>");
+
+    // Test1: 0
+    println!("<======================= Test with v = 0 =====================>");
+    decode_integer(
+        &[0x00],
+        &[
+            Some(0), // u8
+            Some(0), // u16
+            Some(0), // u32
+            Some(0), // u64
+            Some(0), // i8
+            Some(0), // i16
+            Some(0), // i32
+            Some(0), // i64
+            Some(0), // i128
+        ],
+    );
+    // Test2: 1
+    println!("<======================= Test with v = 1 =====================>");
+    decode_integer(
+        &[0x01],
+        &[
+            Some(1), // u8
+            Some(1), // u16
+            Some(1), // u32
+            Some(1), // u64
+            Some(1), // i8
+            Some(1), // i16
+            Some(1), // i32
+            Some(1), // i64
+            Some(1), // i128
+        ],
+    );
+    // Test3: 10
+    println!("<======================= Test with v = 10 =====================>");
+    decode_integer(
+        &[0x0a],
+        &[
+            Some(10), // u8
+            Some(10), // u16
+            Some(10), // u32
+            Some(10), // u64
+            Some(10), // i8
+            Some(10), // i16
+            Some(10), // i32
+            Some(10), // i64
+            Some(10), // i128
+        ],
+    );
+    // Test4: 23
+    println!("<======================= Test with v = 23 =====================>");
+    decode_integer(
+        &[0x17],
+        &[
+            Some(23), // u8
+            Some(23), // u16
+            Some(23), // u32
+            Some(23), // u64
+            Some(23), // i8
+            Some(23), // i16
+            Some(23), // i32
+            Some(23), // i64
+            Some(23), // i128
+        ],
+    );
+    // Test5: 24
+    println!("<======================= Test with v = 24 =====================>");
+    decode_integer(
+        &[0x18, 0x18],
+        &[
+            Some(24), // u8
+            Some(24), // u16
+            Some(24), // u32
+            Some(24), // u64
+            Some(24), // i8
+            Some(24), // i16
+            Some(24), // i32
+            Some(24), // i64
+            Some(24), // i128
+        ],
+    );
+    // Test6: 25
+    println!("<======================= Test with v = 25 =====================>");
+    decode_integer(
+        &[0x18, 0x19],
+        &[
+            Some(25), // u8
+            Some(25), // u16
+            Some(25), // u32
+            Some(25), // u64
+            Some(25), // i8
+            Some(25), // i16
+            Some(25), // i32
+            Some(25), // i64
+            Some(25), // i128
+        ],
+    );
+    // Test7: 100
+    println!("<======================= Test with v = 100 =====================>");
+    decode_integer(
+        &[0x18, 0x64],
+        &[
+            Some(100), // u8
+            Some(100), // u16
+            Some(100), // u32
+            Some(100), // u64
+            Some(100), // i8
+            Some(100), // i16
+            Some(100), // i32
+            Some(100), // i64
+            Some(100), // i128
+        ],
+    );
+    // Test8: 1000
+    println!("<======================= Test with v = 1000 =====================>");
+    decode_integer(
+        &[0x19, 0x03, 0xe8],
+        &[
+            None,       // u8
+            Some(1000), // u16
+            Some(1000), // u32
+            Some(1000), // u64
+            None,       // i8
+            Some(1000), // i16
+            Some(1000), // i32
+            Some(1000), // i64
+            Some(1000), // i128
+        ],
+    );
+    // Test9: 1000000
+    println!("<======================= Test with v = 1000000 =====================>");
+    decode_integer(
+        &[0x1a, 0x00, 0x0f, 0x42, 0x40],
+        &[
+            None,          // u8
+            None,          // u16
+            Some(1000000), // u32
+            Some(1000000), // u64
+            None,          // i8
+            None,          // i16
+            Some(1000000), // i32
+            Some(1000000), // i64
+            Some(1000000), // i128
+        ],
+    );
+    // Test10: 1000000000000
+    println!("<======================= Test with v = 1000000000000 =====================>");
+    decode_integer(
+        &[0x1b, 0x00, 0x00, 0x00, 0xe8, 0xd4, 0xa5, 0x10, 0x00],
+        &[
+            None,                    // u8
+            None,                    // u16
+            None,                    // u32
+            Some(1_000_000_000_000), // u64
+            None,                    // i8
+            None,                    // i16
+            None,                    // i32
+            Some(1_000_000_000_000), // i64
+            Some(1_000_000_000_000), // i128
+        ],
+    );
+    // Test11: 18446744073709551615 (u64::MAX)
+    println!("<======================= Test with v = 18446744073709551615 =====================>");
+    decode_integer(
+        &[0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+        &[
+            None,                             // u8
+            None,                             // u16
+            None,                             // u32
+            Some(18_446_744_073_709_551_615), // u64
+            None,                             // i8
+            None,                             // i16
+            None,                             // i32
+            None,                             // i64
+            Some(18_446_744_073_709_551_615), // i128
+        ],
+    );
+}
+
+// Verify signed integer item decode using iterator API and <type>::try_from(&item) for all cases
+#[test]
+fn rfc8949_decode_sint_manual() {
+    println!("<======================= rfc8949_decode_sint =====================>");
+
+    // Test1: -1
+    println!("<======================= Test with v = -1 =====================>");
+    decode_integer(
+        &[0x20],
+        &[
+            None,     // u8
+            None,     // u16
+            None,     // u32
+            None,     // u64
+            Some(-1), // i8
+            Some(-1), // i16
+            Some(-1), // i32
+            Some(-1), // i64
+            Some(-1), // i128
+        ],
+    );
+    // Test2: -10
+    println!("<======================= Test with v = -10 =====================>");
+    decode_integer(
+        &[0x29],
+        &[
+            None,      // u8
+            None,      // u16
+            None,      // u32
+            None,      // u64
+            Some(-10), // i8
+            Some(-10), // i16
+            Some(-10), // i32
+            Some(-10), // i64
+            Some(-10), // i128
+        ],
+    );
+    // Test3: -100
+    println!("<======================= Test with v = -100 =====================>");
+    decode_integer(
+        &[0x38, 0x63],
+        &[
+            None,       // u8
+            None,       // u16
+            None,       // u32
+            None,       // u64
+            Some(-100), // i8
+            Some(-100), // i16
+            Some(-100), // i32
+            Some(-100), // i64
+            Some(-100), // i128
+        ],
+    );
+    // Test4: -1000
+    println!("<======================= Test with v = -1000 =====================>");
+    decode_integer(
+        &[0x39, 0x03, 0xe7],
+        &[
+            None,        // u8
+            None,        // u16
+            None,        // u32
+            None,        // u64
+            None,        // i8
+            Some(-1000), // i16
+            Some(-1000), // i32
+            Some(-1000), // i64
+            Some(-1000), // i128
+        ],
+    );
+    // Test5: -18446744073709551616 (i64::MIN)
+    println!("<======================= Test with v = -18446744073709551616 =====================>");
+    decode_integer(
+        &[0x3b, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+        &[
+            None,                             // u8
+            None,                             // u16
+            None,                             // u32
+            None,                             // u64
+            None,                             // i8
+            None,                             // i16
+            None,                             // i32
+            Some(-9_223_372_036_854_775_808), // i64
+            Some(-9_223_372_036_854_775_808), // i128
+        ],
+    );
+}
+
+#[test]
+fn rfc8949_decode_bs_manual() {
+    println!("<======================= rfc8949_decode_bs =====================>");
+
+    // Test1: h''
+    println!("<======================= Test with h'' =====================>");
+    decode_bstr(&[0x40], &[]);
+    // Test2: h'01020304'
+    println!("<======================= Test with h'01020304' =====================>");
+    decode_bstr(&[0x44, 0x01, 0x02, 0x03, 0x04], &[01u8, 02u8, 03u8, 04u8]);
+}
+
+#[test]
+fn rfc8949_decode_str_manual() {
+    println!("<======================= rfc8949_decode_str =====================>");
+
+    // Test1: ""
+    println!("<======================= Test with \"\" =====================>");
+    decode_str(&[0x60], "");
+
+    // Test2: "a"
+    println!("<======================= Test with \"a\" =====================>");
+    decode_str(&[0x61, 0x61], "a");
+
+    // Test3: "IETF"
+    println!("<======================= Test with \"IETF\" =====================>");
+    decode_str(&[0x64, 0x49, 0x45, 0x54, 0x46], "IETF");
+
+    // Test4: "\"\\"
+    decode_str(&[0x62, 0x22, 0x5c], "\"\\");
+
+    // Test5: "\u00fc"
+    decode_str(&[0x62, 0xc3, 0xbc], "\u{00fc}");
+
+    // Test6: "\u6c34"
+    decode_str(&[0x63, 0xe6, 0xb0, 0xb4], "\u{6c34}");
+
+    // The below is illegal as Rust requires chars to be Unicode scalar values
+    // which means that only values in [0x0, 0xd7ff] and [0xe000, 0x10ffff] are
+    // legal. In short, RFC7049 has an example which is not actually legal UTF8
+    // - see Unicode Standard, v12.0, Section 3.9, Table 3-7.
+    //decode_ok!([0x64, 0xf0, 0x90, 0x85, 0x91], CBOR::UTF8Str("\u{d800}\u{dd51}".to_string()));
+}
+
+#[test]
+fn rfc8949_decode_arr_manual() {
+    println!("<======================= rfc8949_decode_arr =====================>");
+    // Test1: []
+    println!("\n\nrfc8949_decode_arr - Test 1 - []");
+    decode_integer_array(&[0x80], &[]);
+
+    // Test2: [1, 2, 3]
+    println!("\n\nrfc8949_decode_arr - Test 1 - [1,2,3]");
+    decode_integer_array(&[0x83, 0x01, 0x02, 0x03], &[1, 2, 3]);
+
+    // Test3: [1, [2, 3], [4, 5]] - tests nested array
+    {
+        println!("\n\nrfc8949_decode_arr - Test 3 - [1,[2,3],[4,5]");
+        let items = SequenceBuffer::new(&[0x83, 0x01, 0x82, 0x02, 0x03, 0x82, 0x04, 0x05]);
+        let mut iter = items.into_iter();
+
+        // Iter.nth(0) (same as iter.next()) should return an Array
+        if let Some(CBOR::Array(ab)) = iter.nth(0) {
+            for i in 0..ab.len() {
+                println!("==> i = {}", i);
+                // Yes, it's normally an anti-pattern, but here we need the positional information
+                match (ab.index(i), i) {
+                    // Expect first item to be UInt(1)
+                    (Some(i @ CBOR::UInt(_)), 0) => {
+                        check_int_result!(u8::try_from(&i), Some(1))
+                    }
+                    (Some(CBOR::Array(ab1)), 1) => {
+                        println!("ab1: {:?}", ab1);
+                        // foo
+                        assert!(true)
+                    }
+                    (Some(CBOR::Array(ab2)), 2) => {
+                        println!("ab2: {:?}", ab2);
+                        // bar
+                        assert!(true)
+                    }
+                    e => {
+                        println!("e: {:?}", e);
+                        assert!(false)
+                    }
+                }
+            }
+        }
+    }
+
+    // Test4: [1, 2, 3, .., 24, 25] - tests array with different integer lengths
+    println!("\n\nrfc8949_decode_arr - Test 1 - [1,2,3, .., 24, 25]");
+    decode_integer_array(
+        &[
+            0x98, 0x19, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+            0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x18, 0x18,
+            0x19,
+        ],
+        &[
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+            0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
+        ],
+    );
+}
+
+#[test]
+fn decode_combinators_basic() -> Result<(), CBORError> {
+    println!("<======================= test_decode_combinators =====================>");
+    {
+        // Test 1: two parsers in sequence
+        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8, 0x19, 0x03, 0xe9]).into_iter();
+        let (it, r1) = is_uint()(it)?;
+        let (_it, r2) = is_uint()(it)?;
+        assert!(r1 == CBOR::UInt(1000) && r2 == CBOR::UInt(1001));
+    }
+    {
+        // Test 2: cond
+        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8]).into_iter();
+        let (it, r1) = is_uint()(it)?;
+        let (_next, v) = cond(true, is_eof())(it)?;
+        assert!(r1 == CBOR::UInt(1000) && v == Some(CBOR::Eof));
+    }
+    {
+        // Test 3: opt. First parse succeeds, second is skipped
+        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8]).into_iter();
+        let (it, r1) = opt(is_uint())(it)?;
+        let (_it, r2) = opt(is_bool())(it)?;
+        assert!(r1 == Some(CBOR::UInt(1000)) && r2 == None);
+    }
+    {
+        // Test 4: with_pred, nesting of parsers, sequence of parsers
+        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8, 0x19, 0x03, 0xe9]).into_iter();
+        let (it, r1) = opt(with_pred(is_uint(), |v| {
+            if let CBOR::UInt(value) = *v {
+                value == 1000
+            } else {
+                false
+            }
+        }))(it)?;
+        let (_it, r2) = is_uint()(it)?;
+        assert!(r1 == Some(CBOR::UInt(1000)) && r2 == CBOR::UInt(1001))
+    }
+    {
+        // Test 4: with_pred, nesting of parsers, sequence of parsers
+        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8, 0x19, 0x03, 0xe9]).into_iter();
+        let (it, r1) = opt(with_value(is_uint(), CBOR::UInt(1000)))(it)?;
+        let (_it, r2) = is_uint()(it)?;
+        assert!(r1 == Some(CBOR::UInt(1000)) && r2 == CBOR::UInt(1001))
+    }
+    Ok(())
+}
+
+#[test]
+fn rfc8949_decode_uint_with_combinator() -> Result<(), CBORError> {
+    fn decode_uint(seq: &[u8], v: u64) -> Result<(), CBORError> {
+        println!(
+            "<======================= Test with v = {} =====================>",
+            v
+        );
+        let it = SequenceBuffer::new(seq).into_iter();
+        let (_it, r1) = with_value(is_uint(), CBOR::UInt(v))(it)?;
+        println!("r1 = {:?}, v = {}", r1, v);
+        assert_eq!(r1, CBOR::UInt(v));
+        Ok(())
+    }
+    println!("<======================= rfc8949_decode_uint_with_combinator =====================>");
+    decode_uint(&[0x00], 0)?;
+    decode_uint(&[0x01], 1)?;
+    decode_uint(&[0x0a], 10)?;
+    decode_uint(&[0x17], 23)?;
+    decode_uint(&[0x18, 0x18], 24)?;
+    decode_uint(&[0x18, 0x19], 25)?;
+    decode_uint(&[0x18, 0x64], 100)?;
+    decode_uint(&[0x19, 0x03, 0xe8], 1000)?;
+    decode_uint(&[0x1a, 0x00, 0x0f, 0x42, 0x40], 1000000)?;
+    decode_uint(
+        &[0x1b, 0x00, 0x00, 0x00, 0xe8, 0xd4, 0xa5, 0x10, 0x00],
+        1000000000000,
+    )?;
+    decode_uint(
+        &[0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+        18446744073709551615,
+    )?;
+    Ok(())
+}
+
+#[test]
+fn rfc8949_decode_nint_with_combinator() -> Result<(), CBORError> {
+    fn decode_nint(seq: &[u8], v: i128) -> Result<(), CBORError> {
+        println!(
+            "<======================= Test with v = {} =====================>",
+            v
+        );
+        let nint_repr: u64 = (-v - 1) as u64;
+        let it = SequenceBuffer::new(seq).into_iter();
+        let (_it, r1) = with_value(is_nint(), CBOR::NInt(nint_repr))(it)?;
+        println!("r1 = {:?}, v = {}, nint_repr = {}", r1, v, nint_repr);
+        assert_eq!(r1, CBOR::NInt(nint_repr));
+        Ok(())
+    }
+    println!("<======================= rfc8949_decode_nint_with_combinator =====================>");
+    decode_nint(&[0x20], -1)?;
+    decode_nint(&[0x29], -10)?;
+    decode_nint(&[0x38, 0x63], -100)?;
+    decode_nint(&[0x39, 0x03, 0xe7], -1000)?;
+    decode_nint(
+        &[0x3b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+        -18446744073709551616,
+    )?;
+    Ok(())
+}
+
+#[test]
+fn rfc8949_decode_simple_with_combinator() -> Result<(), CBORError> {
+    println!(
+        "<======================= rfc8949_decode_simple_with_combinator =====================>"
+    );
+    {
+        println!("<======================= Test with false =====================>");
+        let it = SequenceBuffer::new(&[0xf4]).into_iter();
+        let (_, r) = is_false()(it)?;
+        assert_eq!(r, CBOR::False);
+    }
+    {
+        println!("<======================= Test with true =====================>");
+        let it = SequenceBuffer::new(&[0xf5]).into_iter();
+        let (_, r) = is_true()(it)?;
+        assert_eq!(r, CBOR::True);
+    }
+    {
+        println!("<======================= Test with null =====================>");
+        let it = SequenceBuffer::new(&[0xf6]).into_iter();
+        let (_, r) = is_null()(it)?;
+        assert_eq!(r, CBOR::Null);
+    }
+    {
+        println!("<======================= Test with undefined =====================>");
+        let it = SequenceBuffer::new(&[0xf7]).into_iter();
+        let (_, r) = is_undefined()(it)?;
+        assert_eq!(r, CBOR::Undefined);
+    }
+    {
+        println!("<======================= Test with simple(16) =====================>");
+        let it = SequenceBuffer::new(&[0xf0]).into_iter();
+        let (_, r) = with_value(is_simple(), CBOR::Simple(16))(it)?;
+        assert_eq!(r, CBOR::Simple(16));
+    }
+    {
+        println!("<======================= Test with simple(255) =====================>");
+        let it = SequenceBuffer::new(&[0xf8, 0xff]).into_iter();
+        let (_, r) = with_value(is_simple(), CBOR::Simple(255))(it)?;
+        assert_eq!(r, CBOR::Simple(255));
+    }
+    {
+        println!(
+            "<======================= Test with simple(19), simple(253) =====================>"
+        );
+        let it = SequenceBuffer::new(&[0xf3, 0xf8, 0xfd]).into_iter();
+        let (it, r1) = with_value(is_simple(), CBOR::Simple(19))(it)?;
+        let (_, r2) = with_value(is_simple(), CBOR::Simple(253))(it)?;
+        assert_eq!(r1, CBOR::Simple(19));
+        assert_eq!(r2, CBOR::Simple(253));
+    }
+    Ok(())
+}
+
+#[test]
+fn rfc8949_decode_tstr_with_combinator() -> Result<(), CBORError> {
+    fn decode_str(b: &[u8], s: &str) -> Result<(), CBORError> {
+        println!(
+            "<======================= Test with {:?} =====================>",
+            s
+        );
+        let it = SequenceBuffer::new(b).into_iter();
+        let (_, r) = with_value(is_tstr(), CBOR::Tstr(s))(it)?;
+        assert_eq!(r, CBOR::Tstr(s));
+        Ok(())
+    }
+    println!("<======================= rfc8949_decode_tstr_with_combinator =====================>");
+    decode_str(&[0x60], "")?;
+    decode_str(&[0x61, 0x61], "a")?;
+    decode_str(&[0x64, 0x49, 0x45, 0x54, 0x46], "IETF")?;
+    decode_str(&[0x62, 0x22, 0x5c], "\"\\")?;
+    decode_str(&[0x62, 0xc3, 0xbc], "\u{00fc}")?;
+    decode_str(&[0x63, 0xe6, 0xb0, 0xb4], "\u{6c34}")?;
+
+    // The below is illegal as Rust requires chars to be Unicode scalar values
+    // which means that only values in [0x0, 0xd7ff] and [0xe000, 0x10ffff] are
+    // legal. In short, RFC7049 has an example which is not actually legal UTF8
+    // - see Unicode Standard, v12.0, Section 3.9, Table 3-7.
+    // decode_str(false, &[0x64, 0xf0, 0x90, 0x85, 0x91],  "\u{00d800}\u{00dd51}")?;
+    Ok(())
+}
+
+#[test]
+fn rfc8949_decode_bstr_with_combinator() -> Result<(), CBORError> {
+    fn decode_bstr(b: &[u8], bs: &[u8]) -> Result<(), CBORError> {
+        println!(
+            "<======================= Test with {:?} =====================>",
+            bs
+        );
+        let it = SequenceBuffer::new(b).into_iter();
+        let (_, r) = with_value(is_bstr(), CBOR::Bstr(bs))(it)?;
+        assert_eq!(r, CBOR::Bstr(bs));
+        Ok(())
+    }
+    println!("<======================= rfc8949_decode_str_with_combinator =====================>");
+    decode_bstr(&[0x40], &[])?;
+    decode_bstr(&[0x44, 0x01, 0x02, 0x03, 0x04], &[1, 2, 3, 4])?;
+    Ok(())
+}
+
+#[test]
+fn rfc8949_decode_array_with_combinator() -> Result<(), CBORError> {
+    println!(
+        "<======================= rfc8949_decode_array_with_combinator =====================>"
+    );
+    {
+        println!("<======================= Test with empty array =====================>");
+        let it = SequenceBuffer::new(&[0x80]).into_iter();
+        if let (_, CBOR::Array(ab)) = is_array()(it)? {
+            assert_eq!(ab.len(), 0);
+        } else {
+            assert!(false);
+        }
+    }
+    {
+        println!("<======================= Test with [1,2,3] =====================>");
+        let it_seq = SequenceBuffer::new(&[0x83, 0x01, 0x02, 0x03]).into_iter();
+        if let (_, CBOR::Array(ab)) = is_array()(it_seq)? {
+            assert_eq!(ab.len(), 3);
+            let it_array = ab.into_iter();
+            let (it_array, r1) = is_uint()(it_array)?;
+            let (it_array, r2) = is_uint()(it_array)?;
+            let (_it_array, r3) = is_uint()(it_array)?;
+            assert_eq!(r1, CBOR::UInt(1));
+            assert_eq!(r2, CBOR::UInt(2));
+            assert_eq!(r3, CBOR::UInt(3));
+        } else {
+            assert!(false);
+        }
+    }
+    {
+        println!("<======================= Test with [1,[2,3],[4,5]] =====================>");
+        let it_seq =
+            SequenceBuffer::new(&[0x83, 0x01, 0x82, 0x02, 0x03, 0x82, 0x04, 0x05]).into_iter();
+        if let (_, CBOR::Array(ab)) = is_array()(it_seq)? {
+            assert_eq!(ab.len(), 3);
+            let it_array = ab.into_iter();
+            let (it_array, r1) = is_uint()(it_array)?;
+            let (it_array, r2) = is_array()(it_array)?;
+            let (_it_array, r3) = is_array()(it_array)?;
+            assert_eq!(r1, CBOR::UInt(1));
+            if let CBOR::Array(ab2) = r2 {
+                let it_ab2 = ab2.into_iter();
+                let (it_ab2, r2a) = is_uint()(it_ab2)?;
+                let (_it_ab2, r2b) = is_uint()(it_ab2)?;
+                assert!(r2a == CBOR::UInt(2) && r2b == CBOR::UInt(3));
+            } else {
+                assert!(false);
+            }
+            if let CBOR::Array(ab3) = r3 {
+                let it_ab3 = ab3.into_iter();
+                let (it_ab3, r3a) = is_uint()(it_ab3)?;
+                let (_it_ab3, r3b) = is_uint()(it_ab3)?;
+                assert!(r3a == CBOR::UInt(4) && r3b == CBOR::UInt(5))
+            } else {
+                assert!(false);
+            }
+        } else {
+            assert!(false);
+        }
+    }
+    {
+        println!("<======================= Test with [1,2, ..., 25] =====================>");
+        let it_seq = SequenceBuffer::new(&[
+            0x98, 0x19, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+            0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x18, 0x18,
+            0x19,
+        ])
+        .into_iter();
+        if let (_, CBOR::Array(ab)) = is_array()(it_seq)? {
+            assert_eq!(ab.len(), 25);
+            // Note slightly nasty handling of the iterator here...
+            let mut it_array = ab.into_iter();
+            for i in 0..ab.len() {
+                // The iterator is assigned here in a let, so dropped on next loop iteration...
+                let (it_array_tmp, v) = is_uint()(it_array)?;
+                // So we assign it to the mutable copy here, and the value is moved.
+                it_array = it_array_tmp;
+
+                if let CBOR::UInt(num) = v {
+                    assert_eq!((i + 1) as u64, num);
+                } else {
+                    assert!(false);
+                }
+            }
+        } else {
+            assert!(false);
+        }
+    }
+    {
+        println!(
+            "<======================= Test with [\"a\", (\"b\": \"c\")]  =====================>"
+        );
+        let it = SequenceBuffer::new(&[0x82, 0x61, 0x61, 0xa1, 0x61, 0x62, 0x61, 0x63]).into_iter();
+        if let (_, CBOR::Array(ab)) = is_array()(it)? {
+            assert_eq!(ab.len(), 2);
+            assert_eq!(ab.index(0), Some(CBOR::Tstr("a")));
+            if let Some(CBOR::Map(mb2)) = ab.index(1) {
+                assert_eq!(mb2.len(), 1);
+                assert_eq!(
+                    mb2.get_key_value(&CBOR::Tstr("b")),
+                    Some((CBOR::Tstr("b"), CBOR::Tstr("c")))
+                );
+            } else {
+                assert!(false)
+            }
+        } else {
+            assert!(false);
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn rfc8949_decode_map_with_combinator() -> Result<(), CBORError> {
+    println!("<======================= rfc8949_decode_map_with_combinator =====================>");
+    {
+        println!("<======================= Test with empty map =====================>");
+        let it = SequenceBuffer::new(&[0xa0]).into_iter();
+        if let (_, CBOR::Map(mb)) = is_map()(it)? {
+            assert_eq!(mb.len(), 0);
+            assert!(mb.is_empty());
+            assert_eq!(mb.contains_key(&CBOR::UInt(1)), false);
+        } else {
+            assert!(false);
+        }
+    }
+    {
+        println!("<======================= Test with (1: 2, 3: 4)  =====================>");
+        let it = SequenceBuffer::new(&[0xa2, 0x01, 0x02, 0x03, 0x04]).into_iter();
+        if let (_, CBOR::Map(mb)) = is_map()(it)? {
+            assert_eq!(mb.len(), 2);
+            assert_eq!(mb.contains_key(&CBOR::UInt(1)), true);
+            assert_eq!(mb.get(&CBOR::UInt(1)), Some(CBOR::UInt(2)));
+            assert_eq!(
+                mb.get_key_value(&CBOR::UInt(3)),
+                Some((CBOR::UInt(3), CBOR::UInt(4)))
+            );
+        } else {
+            assert!(false);
+        }
+    }
+    {
+        println!(
+            "<======================= Test with (\"a\": 1, \"b\": [2,3])  =====================>"
+        );
+        let it = SequenceBuffer::new(&[0xa2, 0x61, 0x61, 0x01, 0x61, 0x62, 0x82, 0x02, 0x03])
+            .into_iter();
+        if let (_, CBOR::Map(mb)) = is_map()(it)? {
+            assert_eq!(mb.len(), 2);
+            assert_eq!(mb.contains_key(&CBOR::Tstr("a")), true);
+            assert_eq!(mb.get(&CBOR::Tstr("a")), Some(CBOR::UInt(1)));
+            if let Some(CBOR::Array(ab2)) = mb.get(&CBOR::Tstr("b")) {
+                assert_eq!(ab2.len(), 2);
+                assert_eq!(ab2.index(0), Some(CBOR::UInt(2)));
+                assert_eq!(ab2.index(1), Some(CBOR::UInt(3)));
+            } else {
+                assert!(false)
+            }
+        } else {
+            assert!(false);
+        }
+    }
+    {
+        println!(
+            "<======================= Test with (\"a\": \"A\", \"b\": \"B\", \"c\": \"C\", \"d\": \"D\", \"e\": \"E\")  =====================>"
+        );
+        let it = SequenceBuffer::new(&[
+            0xa5, 0x61, 0x61, 0x61, 0x41, 0x61, 0x62, 0x61, 0x42, 0x61, 0x63, 0x61, 0x43, 0x61,
+            0x64, 0x61, 0x44, 0x61, 0x65, 0x61, 0x45,
+        ])
+        .into_iter();
+        if let (_, CBOR::Map(mb)) = is_map()(it)? {
+            assert_eq!(mb.len(), 5);
+            assert_eq!(mb.get(&CBOR::Tstr("a")), Some(CBOR::Tstr("A")));
+            assert_eq!(mb.get(&CBOR::Tstr("e")), Some(CBOR::Tstr("E")));
+            assert_eq!(mb.get(&CBOR::Tstr("c")), Some(CBOR::Tstr("C")));
+            assert_eq!(mb.get(&CBOR::Tstr("d")), Some(CBOR::Tstr("D")));
+            assert_eq!(mb.get(&CBOR::Tstr("b")), Some(CBOR::Tstr("B")));
+        } else {
+            assert!(false);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn rfc8949_decode_tag_with_combinator() -> Result<(), CBORError> {
+    println!("<======================= rfc8949_decode_tag_with_combinator =====================>");
+    {
+        println!(
+            "<======================= Test with 0(\"2013-03-21T20:04:00Z\") =====================>"
+        );
+        let it = SequenceBuffer::new(&[
+            0xc0, 0x74, 0x32, 0x30, 0x31, 0x33, 0x2d, 0x30, 0x33, 0x2d, 0x32, 0x31, 0x54, 0x32,
+            0x30, 0x3a, 0x30, 0x34, 0x3a, 0x30, 0x30, 0x5a,
+        ])
+        .into_iter();
+        if let (_, CBOR::Tag(tb)) = is_tag_with_value(0)(it)? {
+            let t_it = tb.into_iter();
+            if let (_, CBOR::Tstr(s)) = is_tstr()(t_it)? {
+                assert_eq!(s, "2013-03-21T20:04:00Z");
+            } else {
+                assert!(false);
+            }
+        } else {
+            assert!(false);
+        }
+    }
+    {
+        println!("<======================= Test with 1(1363896240) =====================>");
+        let it = SequenceBuffer::new(&[0xc1, 0x1a, 0x51, 0x4b, 0x67, 0xb0]).into_iter();
+        if let (_, CBOR::Tag(tb)) = is_tag_with_value(1)(it)? {
+            let t_it = tb.into_iter();
+            if let (_, CBOR::UInt(v)) = is_uint()(t_it)? {
+                assert_eq!(v, 1363896240);
+            } else {
+                assert!(false);
+            }
+        } else {
+            assert!(false);
+        }
+    }
+    {
+        println!("<======================= Test with 23(h'01020304') =====================>");
+        let it = SequenceBuffer::new(&[0xd7, 0x44, 0x01, 0x02, 0x03, 0x04]).into_iter();
+        if let (_, CBOR::Tag(tb)) = is_tag_with_value(23)(it)? {
+            let t_it = tb.into_iter();
+            if let (_, CBOR::Bstr(bs)) = is_bstr()(t_it)? {
+                assert_eq!(bs, &[1, 2, 3, 4]);
+            } else {
+                assert!(false);
+            }
+        } else {
+            assert!(false);
+        }
+    }
+    {
+        println!("<======================= Test with 24(h'6449455446') =====================>");
+        let it = SequenceBuffer::new(&[0xd8, 0x18, 0x45, 0x64, 0x49, 0x45, 0x54, 0x46]).into_iter();
+        if let (_, CBOR::Tag(tb)) = is_tag_with_value(24)(it)? {
+            let t_it = tb.into_iter();
+            if let (_, CBOR::Bstr(bs)) = is_bstr()(t_it)? {
+                assert_eq!(bs, &[0x64, 0x49, 0x45, 0x54, 0x46]);
+            } else {
+                assert!(false);
+            }
+        } else {
+            assert!(false);
+        }
+    }
+    {
+        println!("<======================= Test with 32(\"http://www.example.com\") =====================>");
+        let it = SequenceBuffer::new(&[
+            0xd8, 0x20, 0x76, 0x68, 0x74, 0x74, 0x70, 0x3a, 0x2f, 0x2f, 0x77, 0x77, 0x77, 0x2e,
+            0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d,
+        ])
+        .into_iter();
+        if let (_, CBOR::Tag(tb)) = is_tag_with_value(32)(it)? {
+            let t_it = tb.into_iter();
+            if let (_, CBOR::Tstr(ts)) = is_tstr()(t_it)? {
+                assert_eq!(ts, "http://www.example.com");
+            } else {
+                assert!(false);
+            }
+        } else {
+            assert!(false);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn rfc8949_decode_float_manual() {
+    println!("<======================= rfc8949_decode_float =====================>");
+
+    // Tests for f16 encodings
+    for (bs, expect) in [
+        ([0xf9, 0x00, 0x00], 0.0),
+        ([0xf9, 0x80, 0x00], -0.0),
+        ([0xf9, 0x3c, 0x00], 1.0),
+        ([0xf9, 0x3e, 0x00], 1.5),
+        ([0xf9, 0x7b, 0xff], 65504.0),
+        ([0xf9, 0x00, 0x01], 5.960464477539063e-8),
+        ([0xf9, 0x04, 0x00], 0.00006103515625),
+        ([0xf9, 0xc4, 0x00], -4.0),
+    ]
+    .iter()
+    {
+        println!(
+            "<======================= Test with {} (f16) =====================>",
+            expect
+        );
+        if let Some(CBOR::Float16(v)) = decode_single(bs) {
+            assert_eq!(v, f16::from_f32(*expect));
+        } else {
+            assert!(false)
+        }
+    }
+
+    println!("<======================= Test +Infinity (f16) =====================>");
+    if let Some(CBOR::Float16(v)) = decode_single(&[0xf9, 0x7c, 0x00]) {
+        assert!(v.is_infinite() && v.is_sign_positive());
+    } else {
+        assert!(false)
+    }
+    println!("<======================= Test NaN (f16) =====================>");
+    if let Some(CBOR::Float16(v)) = decode_single(&[0xf9, 0x7e, 0x00]) {
+        assert!(v.is_nan());
+    } else {
+        assert!(false)
+    }
+    println!("<======================= Test -Infinity (f16) =====================>");
+    if let Some(CBOR::Float16(v)) = decode_single(&[0xf9, 0xfc, 0x00]) {
+        assert!(v.is_infinite() && v.is_sign_negative());
+    } else {
+        assert!(false)
+    }
+
+    // Tests with f32 encodings
+    for (bs, expect) in [
+        ([0xfa, 0x47, 0xc3, 0x50, 0x00], 100000.0),
+        ([0xfa, 0x7f, 0x7f, 0xff, 0xff], 3.4028234663852886e+38f32),
+    ]
+    .iter()
+    {
+        println!(
+            "<======================= Test with {} (f32) =====================>",
+            expect
+        );
+        if let Some(CBOR::Float32(v)) = decode_single(bs) {
+            assert_eq!(v, *expect);
+        } else {
+            assert!(false)
+        }
+    }
+
+    println!("<======================= Test +Infinity (f32) =====================>");
+    if let Some(CBOR::Float32(v)) = decode_single(&[0xfa, 0x7f, 0x80, 0x00, 0x00]) {
+        assert!(v.is_infinite() && v.is_sign_positive());
+    } else {
+        assert!(false)
+    }
+    println!("<======================= Test NaN (f32) =====================>");
+    if let Some(CBOR::Float32(v)) = decode_single(&[0xfa, 0x7f, 0xc0, 0x00, 0x00]) {
+        assert!(v.is_nan());
+    } else {
+        assert!(false)
+    }
+    println!("<======================= Test -Infinity (f32) =====================>");
+    if let Some(CBOR::Float32(v)) = decode_single(&[0xfa, 0xff, 0x80, 0x00, 0x00]) {
+        assert!(v.is_infinite() && v.is_sign_negative());
+    } else {
+        assert!(false)
+    }
+
+    // Tests with f64 encodings
+    for (bs, expect) in [
+        ([0xfb, 0x3f, 0xf1, 0x99, 0x99, 0x99, 0x99, 0x99, 0x9a], 1.1),
+        (
+            [0xfb, 0x7e, 0x37, 0xe4, 0x3c, 0x88, 0x00, 0x75, 0x9c],
+            1.0e+300,
+        ),
+        ([0xfb, 0xc0, 0x10, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66], -4.1),
+    ]
+    .iter()
+    {
+        println!(
+            "<======================= Test with {} (f64) =====================>",
+            expect
+        );
+        if let Some(CBOR::Float64(v)) = decode_single(bs) {
+            assert_eq!(v, *expect);
+        } else {
+            assert!(false)
+        }
+    }
+
+    println!("<======================= Test +Infinity (f64) =====================>");
+    if let Some(CBOR::Float64(v)) =
+        decode_single(&[0xfb, 0x7f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+    {
+        assert!(v.is_infinite() && v.is_sign_positive());
+    } else {
+        assert!(false)
+    }
+    println!("<======================= Test NaN (f64) =====================>");
+    if let Some(CBOR::Float64(v)) =
+        decode_single(&[0xfb, 0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+    {
+        assert!(v.is_nan());
+    } else {
+        assert!(false)
+    }
+    println!("<======================= Test -Infinity (f64) =====================>");
+    if let Some(CBOR::Float64(v)) =
+        decode_single(&[0xfb, 0xff, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+    {
+        assert!(v.is_infinite() && v.is_sign_negative());
+    } else {
+        assert!(false)
+    }
+}

--- a/rs_minicbor/tests/encoder.rs
+++ b/rs_minicbor/tests/encoder.rs
@@ -1,0 +1,515 @@
+/***************************************************************************************************
+ * Copyright (c) 2020, 2021 Jeremy O'Donoghue. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * Test cases from RFC8949, for encoding
+ *
+ * Test cases from RFC7049, Table 4.
+ **************************************************************************************************/
+
+extern crate rs_minicbor;
+
+use rs_minicbor::decoder::*;
+use rs_minicbor::encoder::*;
+use rs_minicbor::error::CBORError;
+use rs_minicbor::types::CBOR;
+
+#[test]
+fn rfc8949_encode_int() -> Result<(), CBORError> {
+    println!("<======================= rfc8949_encode_int =====================>");
+    let mut bytes = [0u8; 32];
+    let u1: &[u8] = &[0x00];
+    let u2: &[u8] = &[0x01];
+    let u3: &[u8] = &[0x0a];
+    let u4: &[u8] = &[0x17];
+    let u5: &[u8] = &[0x18, 0x18];
+    let u6: &[u8] = &[0x18, 0x19];
+    let u7: &[u8] = &[0x18, 0x64];
+    let u8: &[u8] = &[0x19, 0x03, 0xe8];
+    let u9: &[u8] = &[0x1a, 0x00, 0x0f, 0x42, 0x40];
+    let u10: &[u8] = &[0x1b, 0x00, 0x00, 0x00, 0xe8, 0xd4, 0xa5, 0x10, 0x00];
+    let u11: &[u8] = &[0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff];
+    let s1: &[u8] = &[0x20];
+    let s2: &[u8] = &[0x29];
+    let s3: &[u8] = &[0x38, 0x63];
+    let s4: &[u8] = &[0x39, 0x03, 0xe7];
+    let s5: &[u8] = &[0x3b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff];
+
+    // 64 bit encodings
+    for (val, expect) in [
+        (0u64, u1),
+        (1u64, u2),
+        (10u64, u3),
+        (23u64, u4),
+        (24u64, u5),
+        (25u64, u6),
+        (100u64, u7),
+        (1000u64, u8),
+        (1000000u64, u9),
+        (1000000000000u64, u10),
+        (18446744073709551615, u11),
+    ]
+    .iter()
+    {
+        println!(
+            "<======================= Encode u64 {} =====================>",
+            *val
+        );
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, *expect);
+    }
+
+    // 32 bit encodings
+    for (val, expect) in [
+        (0u32, u1),
+        (1u32, u2),
+        (10u32, u3),
+        (23u32, u4),
+        (24u32, u5),
+        (25u32, u6),
+        (100u32, u7),
+        (1000u32, u8),
+        (1000000u32, u9),
+    ]
+    .iter()
+    {
+        println!(
+            "<======================= Encode u32 {} =====================>",
+            *val
+        );
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, *expect);
+    }
+
+    // 16 bit encodings
+    for (val, expect) in [
+        (0u16, u1),
+        (1u16, u2),
+        (10u16, u3),
+        (23u16, u4),
+        (24u16, u5),
+        (25u16, u6),
+        (100u16, u7),
+        (1000u16, u8),
+    ]
+    .iter()
+    {
+        println!(
+            "<======================= Encode u16 {} =====================>",
+            *val
+        );
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, *expect);
+    }
+
+    // 8 bit encodings
+    for (val, expect) in [
+        (0u8, u1),
+        (1u8, u2),
+        (10u8, u3),
+        (23u8, u4),
+        (24u8, u5),
+        (25u8, u6),
+        (100u8, u7),
+    ]
+    .iter()
+    {
+        println!(
+            "<======================= Encode u8 {} =====================>",
+            *val
+        );
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, *expect);
+    }
+
+    // Concatenations
+    {
+        println!("<======================= Concatenate 2 x u32 =====================>");
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        &(1000000u32).encode(&mut buf)?;
+        &(1000001u32).encode(&mut buf)?;
+        assert_eq!(
+            buf.encoded()?,
+            &[0x1a, 0x00, 0x0f, 0x42, 0x40, 0x1a, 0x00, 0x0f, 0x42, 0x41]
+        );
+    }
+
+    // i64 encodings
+    for (val, expect) in [
+        (0i64, u1),
+        (1i64, u2),
+        (10i64, u3),
+        (23i64, u4),
+        (24i64, u5),
+        (25i64, u6),
+        (100i64, u7),
+        (1000i64, u8),
+        (1000000i64, u9),
+        (1000000000000i64, u10),
+        (-1i64, s1),
+        (-10i64, s2),
+        (-100i64, s3),
+        (-1000i64, s4),
+    ]
+    .iter()
+    {
+        println!(
+            "<======================= Encode i64 {} =====================>",
+            *val
+        );
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, *expect);
+    }
+
+    // i32 encodings
+    for (val, expect) in [
+        (0i32, u1),
+        (1i32, u2),
+        (10i32, u3),
+        (23i32, u4),
+        (24i32, u5),
+        (25i32, u6),
+        (100i32, u7),
+        (1000i32, u8),
+        (1000000i32, u9),
+        (-1i32, s1),
+        (-10i32, s2),
+        (-100i32, s3),
+        (-1000i32, s4),
+    ]
+    .iter()
+    {
+        println!(
+            "<======================= Encode i32 {} =====================>",
+            *val
+        );
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, *expect);
+    }
+
+    // i16 encodings
+    for (val, expect) in [
+        (0i16, u1),
+        (1i16, u2),
+        (10i16, u3),
+        (23i16, u4),
+        (24i16, u5),
+        (25i16, u6),
+        (100i16, u7),
+        (1000i16, u8),
+        (-1i16, s1),
+        (-10i16, s2),
+        (-100i16, s3),
+        (-1000i16, s4),
+    ]
+    .iter()
+    {
+        println!(
+            "<======================= Encode i16 {} =====================>",
+            *val
+        );
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, *expect);
+    }
+
+    // i8 encodings
+    for (val, expect) in [
+        (0i16, u1),
+        (1i16, u2),
+        (10i16, u3),
+        (23i16, u4),
+        (24i16, u5),
+        (25i16, u6),
+        (100i16, u7),
+        (-1i16, s1),
+        (-10i16, s2),
+        (-100i16, s3),
+    ]
+    .iter()
+    {
+        println!(
+            "<======================= Encode i8 {} =====================>",
+            *val
+        );
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, *expect);
+    }
+
+    // i128 encodings
+    for (val, expect) in [
+        (0i128, u1),
+        (1i128, u2),
+        (10i128, u3),
+        (23i128, u4),
+        (24i128, u5),
+        (25i128, u6),
+        (100i128, u7),
+        (1000i128, u8),
+        (1000000i128, u9),
+        (1000000000000i128, u10),
+        (-1i128, s1),
+        (-10i128, s2),
+        (-100i128, s3),
+        (-1000i128, s4),
+        (-18446744073709551616i128, s5),
+    ]
+    .iter()
+    {
+        println!(
+            "<======================= Encode i64 {} =====================>",
+            *val
+        );
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, *expect);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn rfc8949_encode_tstr() -> Result<(), CBORError> {
+    println!("<======================= rfc8949_encode_tstr =====================>");
+    let mut bytes = [0u8; 32];
+
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        "".encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0x60]);
+    }
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        "a".encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0x61, 0x61]);
+    }
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        "IETF".encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0x64, 0x49, 0x45, 0x54, 0x46]);
+    }
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        "\"\\".encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0x62, 0x22, 0x5c]);
+    }
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        "\u{00fc}".encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0x62, 0xc3, 0xbc]);
+    }
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        "\u{6c34}".encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0x63, 0xe6, 0xb0, 0xb4]);
+    }
+    Ok(())
+}
+
+#[test]
+fn rfc8949_encode_bstr() -> Result<(), CBORError> {
+    println!("<======================= rfc8949_encode_tstr =====================>");
+    let mut bytes = [0u8; 32];
+
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        let val: &[u8] = &[];
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0x40]);
+    }
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        let val: &[u8] = &[1, 2, 3, 4];
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0x44, 0x01, 0x02, 0x03, 0x04]);
+    }
+    {
+        // Test using the insert API
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        let val: &[u8] = &[1, 2, 3, 4];
+
+        buf.insert(&val)?;
+        assert_eq!(buf.encoded()?, &[0x44, 0x01, 0x02, 0x03, 0x04]);
+    }
+    Ok(())
+}
+
+#[test]
+fn rfc8949_encode_simple() -> Result<(), CBORError> {
+    println!("<======================= rfc8949_encode_simple =====================>");
+    let mut bytes = [0u8; 32];
+
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        let val = &(CBOR::False);
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0xf4]);
+    }
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        let val = &(CBOR::True);
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0xf5]);
+    }
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        let val = &(CBOR::Null);
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0xf6]);
+    }
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        let val = &(CBOR::Undefined);
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0xf7]);
+    }
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        let val = &(CBOR::Simple(16));
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0xf0]);
+    }
+    {
+        let mut buf = EncodeBuffer::new(&mut bytes);
+        let val = &(CBOR::Simple(255));
+        val.encode(&mut buf)?;
+        assert_eq!(buf.encoded()?, &[0xf8, 0xff]);
+    }
+    Ok(())
+}
+
+#[test]
+fn encode_decode_cbor_ast() -> Result<(), CBORError> {
+    // Encode-decode round trip test
+    println!("<======================= rfc8949_encode_decode_cbor_ast =====================>");
+    let mut bytes = [0u8; 128];
+
+    {
+        let val: &[u8] = &[1, 2, 3, 4];
+
+        // values
+        let uval = CBOR::UInt(32);
+        let nval = CBOR::NInt(0xa5a5a5);
+        let sval = CBOR::Tstr("新年快乐");
+        let bval = CBOR::Bstr(&val);
+        let s1 = CBOR::Simple(17);
+        let s2 = CBOR::Simple(234);
+        let s3 = CBOR::False;
+        let tval = CBOR::UInt(0x5a5a5a5a5a5a);
+        let aval1 = CBOR::Tstr("usine à gaz");
+        let aval2 = CBOR::UInt(42);
+        let aval3 = CBOR::Undefined;
+        let mkey1 = CBOR::UInt(1);
+        let mval1 = CBOR::UInt(1023);
+        let mkey2 = CBOR::UInt(2);
+        let mval2 = CBOR::UInt(1025);
+        let mkey3 = CBOR::NInt(1);
+        let mval3 = CBOR::NInt(1024);
+
+        let mut array_ctx = EncodeContext::new();
+        let mut map_ctx = EncodeContext::new();
+        let mut encoded_cbor = CBOREncoder::new(&mut bytes);
+        encoded_cbor
+            .insert(&uval)?
+            .insert(&nval)?
+            .insert(&sval)?
+            .insert(&bval)?
+            .insert(&s1)?
+            .insert(&s2)?
+            .insert(&s3)?
+            .tag_next_item(37)?
+            .insert(&tval)?
+            .array_start(&mut array_ctx)?
+            .insert(&aval1)?
+            .insert(&aval2)?
+            .insert(&aval3)?
+            .array_finalize(&array_ctx)?
+            .map_start(&mut map_ctx)?
+            .insert_key_value(&mkey1, &mval1)?
+            .insert_key_value(&mkey2, &mval2)?
+            .insert_key_value(&mkey3, &mval3)?
+            .map_finalize(&map_ctx)?;
+
+        let _decoder = CBORDecoder::new(encoded_cbor.build()?)
+            .decode_with(is_uint(), |cbor| Ok(assert_eq!(cbor, uval)))?
+            .decode_with(is_nint(), |cbor| Ok(assert_eq!(cbor, nval)))?
+            .decode_with(is_tstr(), |cbor| Ok(assert_eq!(cbor, sval)))?
+            .decode_with(is_bstr(), |cbor| Ok(assert_eq!(cbor, bval)))?
+            .decode_with(is_simple(), |cbor| Ok(assert_eq!(cbor, s1)))?
+            .decode_with(is_simple(), |cbor| Ok(assert_eq!(cbor, s2)))?
+            .decode_with(is_false(), |cbor| Ok(assert_eq!(cbor, s3)))?
+            .decode_with(is_tag_with_value(37), |cbor| {
+                CBORDecoder::from_tag(cbor)?
+                    .decode_with(is_uint(), |cbor| Ok(assert_eq!(cbor, tval)))?
+                    .finalize()
+            })?
+            .decode_with(is_array(), |cbor| {
+                CBORDecoder::from_array(cbor)?
+                    .decode_with(is_tstr(), |cbor| Ok(assert_eq!(cbor, aval1)))?
+                    .decode_with(is_uint(), |cbor| Ok(assert_eq!(cbor, aval2)))?
+                    .decode_with(is_undefined(), |cbor| Ok(assert_eq!(cbor, aval3)))?
+                    .finalize()
+            })?
+            .decode_with(is_map(), |cbor| {
+                if let CBOR::Map(mb) = cbor {
+                    // In the test cases we do not care about the results of these - the assert_eq!()
+                    // tell us all we need.
+                    let _ = mb.get(&mkey1).map_or_else(
+                        || Err(CBORError::KeyNotPresent),
+                        |v| Ok(assert_eq!(v, mval1)),
+                    );
+                    let _ = mb.get(&mkey2).map_or_else(
+                        || Err(CBORError::KeyNotPresent),
+                        |v| Ok(assert_eq!(v, mval2)),
+                    );
+                    let _ = mb.get(&mkey3).map_or_else(
+                        || Err(CBORError::KeyNotPresent),
+                        |v| Ok(assert_eq!(v, mval3)),
+                    );
+                    Ok(())
+                } else {
+                    Err(CBORError::ExpectedType("Map"))
+                }
+            })?;
+    }
+    {
+        let date_time_str = "2013-03-21T20:04:00Z";
+        match chrono::DateTime::parse_from_rfc3339(date_time_str) {
+            Ok(date_time_val) => {
+                let date_time = CBOR::DateTime(date_time_val);
+                let epoch = CBOR::Epoch(1626198094);
+
+                let mut encoded_cbor = CBOREncoder::new(&mut bytes);
+                encoded_cbor.insert(&date_time)?.insert(&epoch)?;
+
+                let _decoder = CBORDecoder::new(encoded_cbor.build()?)
+                    .decode_with(is_date_time(), |cbor| Ok(assert_eq!(cbor, date_time)))?
+                    .decode_with(is_epoch(), |cbor| Ok(assert_eq!(cbor, epoch)))?;
+            }
+            Err(_) => assert!(false),
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Features
- no_std support
- Support all core RFC8949 datatypes for definite length encoding
- Optionally disable float support
- Optional function tracing for debug
- Preferred integer encoding
- Extensive suite of RFC8949-based tests
- Support Epoch and Date/Time tag values

Not supported
- Preferred floating point encoding
- Content hint tags
- Bignum, Bigfloat and decimal fractions
- Preferred encoding of maps
- Canonical encoding of maps
- Indefinite length encoding

Notable behaviours
- Desrialization of a tstr that contains invalid UTF-8 is an error.

Signed-off-by: Jeremy O'Donoghue <quic_jodonogh@quicinc.com>