### PR TITLE
Merge deterministic ECDSA updates to trivial_cose example

### DIFF
--- a/rs_minicbor/Cargo.toml
+++ b/rs_minicbor/Cargo.toml
@@ -60,11 +60,8 @@ func_trace = "1.0.3"                                # MIT licensed
 chrono = { version = "0.4.22", optional = true }    # Dual-licensed, MIT or Apache-2.0
 
 # The below dependencies are needed to buidl/run the trivial_cose examples
-ring = "0.16.20"                                    # Basically BoringSSL. ISC + 3 Clause BSD + MIT
-crypto-bigint = "0.4.9"
-rfc6979 = "0.3.0"
-sha2 = "0.10.6"
-p256 = { version = "0.11.1", features = ["ecdsa"] }
+p256 = { version = "0.11.1", features = ["arithmetic", "ecdsa", "ecdsa-core"] } # Dual-licensed: MIT or Apache-2.0
+crypto-bigint = "0.4.9"                             # Dual-licensed, MIT or Apache-20.
 
 [profile.release]
 opt-level = 'z'   # Optimize for size.


### PR DESCRIPTION
The previous trivial_cose example code, while generating a valid ECDSA signature, did not generate the expected signature value in RFC9052 Appendix C.2.1, which was mildly annoying.

This commit fixes the problem by changing to use the Rust p256 crypto crate which supports deterministic signing according to RFC6979, and thus generates the expected signature (in the previous example, a random nonce was generated by the underlying crypto library.

Code is actually slightly simplified as a result of using the p256 crate.