### PR TITLE
Enhanced CBOR Decoder API

### DIFF
--- a/rot13_service/src/lib.rs
+++ b/rot13_service/src/lib.rs
@@ -222,11 +222,11 @@ pub fn message_handler<'b>(
     in_msg_buf: &'b [u8],
     out_msg_buf: &'b mut [u8],
 ) -> Result<(), CBORError> {
-    let mut decoder = CBORDecoder::new(SequenceBuffer::new(in_msg_buf));
+    let decoder = CBORDecoder::new(SequenceBuffer::new(in_msg_buf));
     // The tag contains the message ID
     decoder.decode_with(is_tag(), |cbor| {
         let mut msg_id: u64 = 0;
-        let mut msg_body = CBORDecoder::from_tag(cbor, &mut msg_id)?;
+        let msg_body = CBORDecoder::from_tag(cbor, &mut msg_id)?;
         let mut encoder = CBORBuilder::new(out_msg_buf);
         match msg_id as u32 {
             // GET_FEATURES_REQ (tag 1) - Don't care about contents
@@ -331,7 +331,7 @@ fn rot13_req_helper<'b>(
     decoder: &'b CBOR<'b>,
     encoder: &'b mut CBORBuilder<'b>,
 ) -> Result<(), CBORError> {
-    let may_plaintext = decoder.try_into_str();
+    let may_plaintext = <&str>::try_from(*decoder);
 
     let (msg_id, text_key) = if op == Rot13Operation::Encode {
         (GPP_ROT13_ENCRYPT_RSP, GPP_ROT13_CIPHERTEXT_KEY)

--- a/tps_cddl/Cargo.toml
+++ b/tps_cddl/Cargo.toml
@@ -18,7 +18,7 @@
 # rs_cddl package definition
 
 [package]
-name = "rs_cddl"
+name = "tps_cddl"
 version = "0.1.0"
 authors = ["Jeremy O'Donoghue <quic_jodonogh@quicinc.com>"]
 edition = "2018"

--- a/tps_cddl/src/bin/astdump/main.rs
+++ b/tps_cddl/src/bin/astdump/main.rs
@@ -24,11 +24,11 @@
  * - Determining whether a CDDL file is syntactically correct
  * - Investigation and analysis of how code generation will work
  **************************************************************************************************/
-extern crate rs_cddl;
+extern crate tps_cddl;
 extern crate clap;
 extern crate thiserror;
 
-use rs_cddl::cddl::*;
+use tps_cddl::cddl::*;
 
 use clap::{App, Arg};
 use std::error::Error;

--- a/tps_cddl/src/bin/cddlgen/ir.rs
+++ b/tps_cddl/src/bin/cddlgen/ir.rs
@@ -20,7 +20,7 @@
  * Intermediate representation used to post-process from the AST
  **************************************************************************************************/
 use std::collections::HashMap;
-use rs_cddl::cddl::{Type, Value};
+use tps_cddl::cddl::{Type, Value};
 use crate::error::CddlError;
 
 #[derive(Debug)]

--- a/tps_cddl/src/bin/cddlgen/main.rs
+++ b/tps_cddl/src/bin/cddlgen/main.rs
@@ -22,11 +22,11 @@
 mod ir;
 mod error;
 
-extern crate rs_cddl;
+extern crate tps_cddl;
 extern crate clap;
 extern crate thiserror;
 
-use rs_cddl::cddl::*;
+use tps_cddl::cddl::*;
 
 use clap::{App, Arg};
 use std::error::Error;

--- a/tps_minicbor/Cargo.toml
+++ b/tps_minicbor/Cargo.toml
@@ -19,7 +19,7 @@
 
 [package]
 name = "tps_minicbor"
-version = "0.3.1"
+version = "0.4.1"
 authors = ["Jeremy O'Donoghue<quic_jodonogh@quicinc.com"]
 edition = "2018"
 license-file = "LICENSE.txt"
@@ -37,9 +37,9 @@ required_features = ["full"]
 name = "trivial_cose"
 required_features = ["full"]
 
-# rs_minicbor can be built in the following variants:
-# - default: (no_std) No allocator or standard library required. Logging, indefinite length messaging
-#   and high-level API are not allowed as a consequence since these require an allocator.
+# tps_minicbor can be built in the following variants:
+# - default: (no_std) No allocator or standard library required. Logging, standard tags
+#   not allowed as a consequence since these require an allocator.
 # - full: (std) Requires standard library. Optionally supports logging, indefinite length messaging and a
 #   higher-level API which can be easier to use.
 

--- a/tps_minicbor/examples/decode.rs
+++ b/tps_minicbor/examples/decode.rs
@@ -32,10 +32,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let item = it.next();
 
     if let Some(item) = item {
-        let v1 = u16::try_from(&item); // should succeed
-        let v2 = u32::try_from(&item); // should succeed
-        let v3 = i32::try_from(&item); // should succeed
-        let v4 = u8::try_from(&item); // should fail
+        let v1 = u16::try_from(item); // should succeed
+        let v2 = u32::try_from(item); // should succeed
+        let v3 = i32::try_from(item); // should succeed
+        let v4 = u8::try_from(item); // should fail
         println!("v1 = {:?}, v2 = {:?}, v3 = {:?}, v4 = {:?}", v1, v2, v3, v4);
     }
 

--- a/tps_minicbor/src/decode.rs
+++ b/tps_minicbor/src/decode.rs
@@ -23,6 +23,32 @@
  * This implementation is designed for use in constrained systems and requires neither the Rust
  * standard library nor an allocator.
  **************************************************************************************************/
+/// # Low-level CBOR decoding functions
+///
+/// This module contains the low-level CBOR decoding primitives. While it is generally recommended
+/// to parse CBOR using the higher-level primitives in the [`decode_combinators`] module, where
+/// memory is very constrained, the low level parsing functions allow for a reasonably comfortable
+/// iterator-based decoding style.
+///
+/// CBOR input is parsed via a [`SequenceBuffer`], which is a constructed over a byte slice and
+/// keeps track of the current parse position and the like.
+///
+/// ## Example
+///
+/// ```
+///# use std::convert::TryFrom;
+///# use tps_minicbor::decoder::SequenceBuffer;
+///# use tps_minicbor::types::CBOR;
+/// let b = [0x18u8; 0x18];
+/// let buf = SequenceBuffer::new(&b);
+/// let mut it = buf.into_iter();
+/// if let Some(cbor) = it.next() {
+///     assert_eq!(CBOR::UInt(24), cbor);
+/// } else {
+///     assert!(false)
+/// }
+/// ```
+
 use crate::array::ArrayBuf;
 use crate::ast::CBOR;
 use crate::constants::*;
@@ -116,6 +142,13 @@ pub struct SequenceBuffer<'buf> {
 
 impl<'buf> SequenceBuffer<'buf> {
     /// Construct a new instance of `DecodeBuf` with all context initialized.
+    ///
+    /// ## Example
+    /// ```
+    ///# use tps_minicbor::decoder::SequenceBuffer;
+    /// let b = [0x18u8; 0x18];
+    /// let buf = SequenceBuffer::new(&b);
+    /// ```
     #[cfg_attr(feature = "trace", trace)]
     pub fn new(init: &'buf [u8]) -> SequenceBuffer<'buf> {
         SequenceBuffer { bytes: init }

--- a/tps_minicbor/src/decode_combinators.rs
+++ b/tps_minicbor/src/decode_combinators.rs
@@ -26,10 +26,117 @@
  * The decode combinators do make use of dynamic dispatch and have some memory penalty in return
  * for a more comfortable API. They can be disabled using the `embedded` build feature.
  **************************************************************************************************/
+/// # CBOR Decode Combinators
+///
+/// The decode combinator library is designed to make it much easier to write CBOR decoding
+/// libraries. It supports two different approaches to writing code, depending on the use-case.
+///
+/// ## Direct decoding of values
+///
+/// This approach updates mutable variables with values read from a [`CBORDecoder`] buffer.
+/// It has the advantage that does not require potentially deep nesting of closures, and works
+/// well when decoding into mutable data structures.
+///
+/// In general, this approach is recommended as it generally results in shorter and more concise
+/// code.
+///
+/// The example shows how several common CBOR items can be decoded:
+///
+/// ```
+///# use tps_minicbor::decoder::*;
+///# use tps_minicbor::encoder::*;
+///# use tps_minicbor::error::CBORError;
+///# use tps_minicbor::types::{array, map, tag, CBOR};
+///
+///# fn main() -> Result<(), CBORError> {
+///     let mut input: &[u8] = &[
+///         0xa2, 0x0a, 0x48, 0x94, 0x8f, 0x88, 0x60, 0xd1, 0x3a, 0x46, 0x3e,
+///         0x19, 0x01, 0x04, 0x82, 0x63, 0x33, 0x2e, 0x31, 0x01
+///     ];
+///     let mut vsn_string = String::new();
+///     let mut nonce = [].as_slice();
+///     let mut hw_vsn_s = "";
+///     let mut hw_vsn_v = 0u64;
+///
+///     let decoder = CBORDecoder::from_slice(&mut input);
+///     let _d = decoder.map(|mb| {
+///         nonce = mb.lookup(10)?;
+///         let ab: ArrayBuf = mb.lookup(260)?;
+///         // Any bstr or tstr needs to be deep copied somewhere that
+///         // definitely lives longer than the closure if we wish to use it
+///         // outside. Here we copy into a string which is inferred to outlive
+///         // the closure.
+///         vsn_string = String::from(ab.item::<&str>(0)?);
+///         hw_vsn_s = &vsn_string;
+///         hw_vsn_v = ab.item(1)?;
+///          Ok(())
+///     })?;
+///     assert_eq!(nonce, &[0x94, 0x8f, 0x88, 0x60, 0xd1, 0x3a, 0x46, 0x3e]);
+///     assert_eq!(hw_vsn_v, 1);
+///     assert_eq!(hw_vsn_s, "3.1");
+///     Ok(())
+///# }
+/// ```
+///
+/// ## Decode Items within a closure
+///
+/// This approach is always used with [`Array`] and [`Map`] types, and may be used with any CBOR
+/// item if it is best handled in closure context.
+///
+/// > **Note:** Support for use of this style outside of closures may be removed in a future
+/// > version of the library.
+///
+/// In this style, a call to [`CBORDecoder::decode_with`] is made using one of the CBOR matching
+/// parsers such as `is_tstr()`. If the expected type is matched, the provided closure is called
+/// with the current CBOR item, and the caller can act on it.
+///
+/// ```
+///# use std::convert::TryFrom;
+///# use tps_minicbor::decoder::*;
+///# use tps_minicbor::encoder::*;
+///# use tps_minicbor::error::CBORError;
+///# use tps_minicbor::types::{array, map, tag, CBOR};
+///# fn main() -> Result<(), CBORError> {
+///     let mut bytes = [0u8; 128];
+///     let mut encoded_cbor = CBORBuilder::new(&mut bytes);
+///     encoded_cbor
+///         .insert(&32u8)?
+///         .insert(&(-(0xa5a5a5i32)))?
+///         .insert(&"新年快乐")?
+///         .insert(&array(|buf| {
+///             buf.insert(&42u8)?
+///                 .insert(&CBOR::Undefined)
+///         }))?;
+///
+///     let _decoder = CBORDecoder::new(encoded_cbor.build()?)
+///         .decode_with(is_uint(), |cbor| {
+///             Ok(assert_eq!(u32::try_from(cbor)?, 32u32))
+///         })?
+///         .decode_with(is_nint(), |cbor| {
+///             Ok(assert_eq!(i32::try_from(cbor)?, -(0xa5a5a5i32)))
+///         })?
+///         .decode_with(is_tstr(), |cbor| {
+///             Ok(assert_eq!(<&str>::try_from(cbor)?, "新年快乐"))
+///         })?
+///         .decode_with(is_array(), |cbor| {
+///             CBORDecoder::from_array(cbor)?
+///                 .decode_with(is_uint(), |cbor| Ok(assert_eq!(u8::try_from(cbor)?, 42)))?
+///                 .decode_with(is_undefined(), |cbor| Ok(assert_eq!(cbor, CBOR::Undefined)))?
+///                 .finalize()
+///         })?;
+///     Ok(())
+///# }
+/// ```
+
+use crate::array::ArrayBuf;
 use crate::ast::CBOR;
 use crate::decode::{DecodeBufIterator, SequenceBuffer};
 use crate::error::CBORError;
+use crate::map::MapBuf;
+use crate::tag::TagBuf;
+use core::convert::TryFrom;
 
+use std::cell::{Ref, RefCell};
 use std::convert::From;
 
 /// Alias for the Result type for all CBOR decode combinators.
@@ -43,7 +150,7 @@ type DCPResult<'buf, O> = core::result::Result<(DecodeBufIterator<'buf>, O), CBO
 
 #[cfg(feature = "combinators")]
 pub struct CBORDecoder<'buf> {
-    decode_buf_iter: DecodeBufIterator<'buf>,
+    decode_buf_iter: RefCell<DecodeBufIterator<'buf>>,
 }
 
 #[cfg(feature = "combinators")]
@@ -52,15 +159,24 @@ impl<'buf> CBORDecoder<'buf> {
     #[inline]
     pub fn new(b: SequenceBuffer<'buf>) -> Self {
         Self {
-            decode_buf_iter: b.into_iter(),
+            decode_buf_iter: RefCell::new(b.into_iter()),
         }
     }
 
-    /// Construct a new instance of a `CBORDecoder` from a `SequenceBuffer`.
+    /// Construct a new instance of a `CBORDecoder` from a &[u8] slice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tps_minicbor::decoder::{CBORDecoder};
+    ///
+    /// let decoder = CBORDecoder::from_slice(&[0x73, 0x49, 0x20, 0x6c, 0x6f, 0x76, 0x65, 0x20,
+    ///   0x74, 0x70, 0x73, 0x5f, 0x6d, 0x69, 0x6e, 0x69, 0x63, 0x62, 0x6f, 0x72]);
+    /// ```
     #[inline]
     pub fn from_slice(b: &'buf [u8]) -> Self {
         Self {
-            decode_buf_iter: SequenceBuffer::new(b).into_iter(),
+            decode_buf_iter: RefCell::new(SequenceBuffer::new(b).into_iter()),
         }
     }
 
@@ -71,7 +187,7 @@ impl<'buf> CBORDecoder<'buf> {
         if let CBOR::Tag(tb) = cbor {
             *tag_value = tb.get_tag();
             Ok(Self {
-                decode_buf_iter: tb.into_iter(),
+                decode_buf_iter: RefCell::new(tb.into_iter()),
             })
         } else {
             Err(CBORError::ExpectedType("CBOR Map"))
@@ -80,11 +196,31 @@ impl<'buf> CBORDecoder<'buf> {
 
     /// Construct an instance of `CBORDecoder` from a CBOR Array, allowing decoding within a CBOR
     /// Array using the CBORDecoder API.
+    ///
+    /// The main use-case for this function occurs when dealing with an array which is nested in a
+    /// map or other array.
+    ///
+    /// # Example
+    ///
+    /// ```
+    ///  use tps_minicbor::decoder::{CBORDecoder};
+    ///
+    ///  let _ = CBORDecoder::from_slice(&[0x82, 0x61, 0x61, 0xa1, 0x61, 0x62, 0x61, 0x63])
+    ///             .array(|ab| {
+    ///                 assert_eq!(ab.len(), 2);
+    ///                 let _ = CBORDecoder::from_array(ab.item(2)?)?
+    ///                     .map(|mb| {
+    ///                     assert_eq!(mb.lookup::<&str, &str>("b")?, "c");
+    ///                     Ok(())
+    ///                 });
+    ///                 Ok(())
+    ///             });
+    /// ```
     #[inline]
     pub fn from_array(cbor: CBOR<'buf>) -> Result<Self, CBORError> {
         if let CBOR::Array(ab) = cbor {
             Ok(Self {
-                decode_buf_iter: ab.into_iter(),
+                decode_buf_iter: RefCell::new(ab.into_iter()),
             })
         } else {
             Err(CBORError::ExpectedType("CBOR Array"))
@@ -97,7 +233,7 @@ impl<'buf> CBORDecoder<'buf> {
     pub fn from_map(cbor: CBOR<'buf>) -> Result<Self, CBORError> {
         if let CBOR::Map(mb) = cbor {
             Ok(Self {
-                decode_buf_iter: mb.into_iter(),
+                decode_buf_iter: RefCell::new(mb.into_iter()),
             })
         } else {
             Err(CBORError::ExpectedType("CBOR Map"))
@@ -106,8 +242,8 @@ impl<'buf> CBORDecoder<'buf> {
 
     /// Obtain the internal iterator of a `CBORDecoder`
     #[inline]
-    pub fn into_inner(&self) -> DecodeBufIterator {
-        self.decode_buf_iter
+    pub fn into_inner(&self) -> Ref<DecodeBufIterator> {
+        self.decode_buf_iter.borrow()
     }
 
     /// When decoding maps, arrays and tags, the closures require finalizing to obtain
@@ -117,23 +253,216 @@ impl<'buf> CBORDecoder<'buf> {
         Ok(())
     }
 
+    /// Decode a value from a [`CBORDecoder`] instance.
+    ///
+    /// The compiler will attempt, if required, to convert the returned value, which depends on the
+    /// parsing function called, into the type of `value`, which is mutably borrowed from the
+    /// caller.
+    ///
+    /// # Parameters
+    ///
+    /// - `parser`: A parsing function which attempts to decode the expected type at the current
+    ///   position in the `CBORDecoder` buffer, `self`. For example, if you are expecting an
+    ///   integer in the buffer, you could call [`decode_int`].
+    /// - `value`: A mutably borrowed value which is updated with the value read from CBOR if:
+    ///   (1) the parse succeeded and (2) the parsed value can be converted into the provided type,
+    ///   which depends on having a suitable instance of `TryFrom`. The crate provides suitable
+    ///   instances for common types.
+    ///
+    /// # Return
+    ///
+    /// - **Good case**: `&Self` is returned, i.e. the CBORDecoder is returned with the last value
+    ///   parsed, and the internal state pointing to the start of the next CBOR item.
+    /// - **Failure case**: A [`CBORError`] instance which provides information about the reason
+    ///  for the failure
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tps_minicbor::decoder::{CBORDecoder, decode_tstr};
+    ///
+    /// let mut result = "deadbeef";
+    /// let _decoder = CBORDecoder::from_slice(&[0x73, 0x49, 0x20, 0x6c, 0x6f, 0x76, 0x65, 0x20,
+    ///   0x74, 0x70, 0x73, 0x5f, 0x6d, 0x69, 0x6e, 0x69, 0x63, 0x62, 0x6f, 0x72])
+    ///   .value(decode_tstr(), &mut result);
+    /// assert_eq!(result, "I love tps_minicbor");
+    ///
+    /// ```
+    pub fn value<'t, F, T: Copy, V>(&self, parser: F, value: &'t mut V) -> Result<&Self, CBORError>
+    where
+        'buf: 't,
+        V: TryFrom<T> + Clone,
+        F: Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, T>,
+    {
+        let (it, v) = parser(self.decode_buf_iter.borrow().clone())?;
+        self.decode_buf_iter.replace(it);
+        match V::try_from(v) {
+            Ok(val) => {
+                *value = val;
+                Ok(self)
+            }
+            Err(_) => Err(CBORError::IncompatibleType),
+        }
+    }
+
+    /// Obtain a [`MapBuf`] from a [`CBORDecoder`] instance, to allow decoding of the map contents.
+    ///
+    /// The library will attempt to obtain a [`MapBuf`] instance, which will succeed if the current
+    /// decoding position in the `CBORDecoder` is the start of a CBOR map.
+    ///
+    /// The [`MapBuf`] structure provides convenience methods for decoding CBOR items contained
+    /// in a map, such as lookup value with key.
+    ///
+    /// # Parameters
+    ///
+    /// - `closure`: A `FnOnce` closure which takes a [`MapBuf`] parameter. If the current decoding
+    ///   position is at the start of a map, this closure will be called with a [`MapBuf`] instance
+    ///   that allows processing of the map in a map-like manner, using the methods of the
+    ///   [`MapBuf`] structure.
+    ///
+    /// # Return
+    ///
+    /// - **Good case**: `&Self` is returned, i.e. the CBORDecoder is returned with the internal
+    ///   state pointing to the start of the CBOR item after the end of the map.
+    /// - **Failure case**: A [`CBORError`] instance which provides information about the reason
+    ///  for the failure, for example, that the current decoding position is not pointing to a map.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tps_minicbor::decoder::{CBORDecoder, decode_tstr};
+    ///
+    /// let _ = CBORDecoder::from_slice(&[0xa2, 0x01, 0x02, 0x03, 0x04])
+    ///     .map(|mb| {
+    ///        assert_eq!(mb.len(), 2);
+    ///        assert_eq!(mb.lookup::<u8, u8>(1)?, 2);
+    ///        assert_eq!(mb.lookup::<u8, u8>(3)?, 4);
+    ///        Ok(())
+    ///     });
+    /// ```
+    pub fn map<C>(&self, closure: C) -> Result<&Self, CBORError>
+    where
+        C: FnOnce(MapBuf<'buf>) -> Result<(), CBORError>,
+    {
+        let (it, mb) = decode_map()(self.decode_buf_iter.borrow().clone())?;
+        self.decode_buf_iter.replace(it);
+        closure(mb)?;
+        Ok(self)
+    }
+
+    /// Obtain an [`ArrayBuf`] from a [`CBORDecoder`] instance, to allow decoding of the array
+    /// contents.
+    ///
+    /// The library will attempt to obtain an [`ArrayBuf`] instance, which will succeed if the
+    /// current decoding position in the `CBORDecoder` is the start of a CBOR map.
+    ///
+    /// The [`ArrayBuf`] structure provides convenience methods for decoding CBOR items stored in
+    /// in an array structure, such as lookup by position in the array.
+    ///
+    /// # Parameters
+    ///
+    /// - `closure`: A `FnOnce` closure which takes a [`MapBuf`] parameter. If the current decoding
+    ///   position is at the start of an array, this closure will be called with an [`ArrayBuf`]
+    ///   instance that allows processing of the array in an array-like manner, using the methods
+    ///   of the [`ArrayBuf`] structure.
+    ///
+    /// # Return
+    ///
+    /// - **Good case**: `&Self` is returned, i.e. the CBORDecoder is returned with the internal
+    ///   state pointing to the start of the CBOR item after the end of the array.
+    /// - **Failure case**: A [`CBORError`] instance which provides information about the reason
+    ///  for the failure, for example, that the current decoding position is not pointing to an
+    /// array.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tps_minicbor::decoder::{CBORDecoder, decode_tstr};
+    ///
+    /// let _ = CBORDecoder::from_slice(&[
+    ///    0x98, 0x19, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+    ///    0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x18, 0x18,
+    ///    0x19,
+    /// ])
+    ///   .array(|ab| {
+    ///     for i in 0..=ab.len() {
+    ///        assert_eq!(ab.item::<u8>(i)?, i.clone() as u8 + 1);
+    ///     }
+    ///     Ok(())
+    /// });
+    /// ```
+    pub fn array<C>(&self, closure: C) -> Result<&Self, CBORError>
+    where
+        C: FnOnce(ArrayBuf<'buf>) -> Result<(), CBORError>,
+    {
+        let (it, ab) = decode_array()(self.decode_buf_iter.borrow().clone())?;
+        self.decode_buf_iter.replace(it);
+        closure(ab)?;
+        Ok(self)
+    }
+
+    /// Obtain an [`TagBuf`] from a [`CBORDecoder`] instance, to allow decoding of the tagged
+    /// contents.
+    ///
+    /// The library will attempt to obtain an [`TagBuf`] instance, which will succeed if the
+    /// current decoding position in the `CBORDecoder` is the start of a tagged CBOR item.
+    ///
+    /// The [`TagBuf`] structure provides convenience methods for decoding the CBOR item stored in
+    /// in the tagged structure.
+    ///
+    /// # Parameters
+    ///
+    /// - `closure`: A `FnOnce` closure which takes a [`TagBuf`] parameter. If the current decoding
+    ///   position is at the start of a tagged item, this closure will be called with a [`TagBuf`]
+    ///   instance that allows processing of the item.
+    ///
+    /// # Return
+    ///
+    /// - **Good case**: `&Self` is returned, i.e. the CBORDecoder is returned with the internal
+    ///   state pointing to the start of the CBOR item after the tagged item.
+    /// - **Failure case**: A [`CBORError`] instance which provides information about the reason
+    ///  for the failure, for example, that the current decoding position is not pointing to an
+    /// array.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tps_minicbor::decoder::{CBORDecoder, decode_tstr};
+    ///
+    /// let _ = CBORDecoder::from_slice(&[0xc1, 0x1a, 0x51, 0x4b, 0x67, 0xb0])
+    ///     .tag(|tb| {
+    ///         if tb.get_tag() == 1 {
+    ///             let result = tb.item::<u64>().unwrap();
+    ///             assert_eq!(result, 1363896240);
+    ///         } else {
+    ///             assert!(false)
+    ///         }
+    ///         Ok(())
+    ///     });
+    /// ```
+    pub fn tag<C>(&self, closure: C) -> Result<&Self, CBORError>
+    where
+        C: FnOnce(TagBuf<'buf>) -> Result<(), CBORError>,
+    {
+        let (it, tb) = decode_tag()(self.decode_buf_iter.borrow().clone())?;
+        self.decode_buf_iter.replace(it);
+        closure(tb)?;
+        Ok(self)
+    }
+
     /// Run `parser` over the next item in the iterator. If it completes successfully, run
     /// `closure` using the result obtained. This allows some result to be built up from
     /// parsing.
     ///
     /// TODO: currently the lifetime management does not allow assignment of references to `self`
     /// within the `closure`.
-    pub fn decode_with<F, C>(
-        &'buf mut self,
-        parser: F,
-        mut closure: C,
-    ) -> Result<&'buf mut Self, CBORError>
+    pub fn decode_with<F, C>(&'buf self, parser: F, mut closure: C) -> Result<&'buf Self, CBORError>
     where
         F: Fn(DecodeBufIterator<'buf>) -> DCResult<'buf>,
         C: FnMut(CBOR<'buf>) -> Result<(), CBORError>,
     {
-        let (it, cbor) = parser(self.decode_buf_iter.clone())?;
-        self.decode_buf_iter = it;
+        let (it, cbor) = parser(self.decode_buf_iter.borrow().clone())?;
+        self.decode_buf_iter.replace(it);
         closure(cbor)?;
         Ok(self)
     }
@@ -144,13 +473,13 @@ impl<'buf> CBORDecoder<'buf> {
     ///
     /// TODO: currently the lifetime management does not allow assignment of references to `self`
     /// within the `closure`.
-    pub fn opt<F, C>(&mut self, parser: F, closure: C) -> Result<&mut Self, CBORError>
+    pub fn opt<F, C>(&self, parser: F, closure: C) -> Result<&Self, CBORError>
     where
         F: Fn(DecodeBufIterator<'buf>) -> DCResult<'buf>,
         C: Fn(CBOR<'buf>) -> Result<(), CBORError>,
     {
-        let (it, opt_cbor) = opt(&parser)(self.decode_buf_iter.clone())?;
-        self.decode_buf_iter = it;
+        let (it, opt_cbor) = opt(&parser)(self.decode_buf_iter.borrow().clone())?;
+        self.decode_buf_iter.replace(it);
         if let Some(cbor) = opt_cbor {
             closure(cbor)?;
         }
@@ -160,12 +489,12 @@ impl<'buf> CBORDecoder<'buf> {
     /// Run `parser` over the next item in the iterator. If it completes successfully, do nothing.
     /// If the parse fails, an error value will be returned.
     #[inline]
-    pub fn ignore<F, C>(&mut self, parser: F) -> Result<&mut Self, CBORError>
+    pub fn ignore<F, C>(&self, parser: F) -> Result<&Self, CBORError>
     where
         F: Fn(DecodeBufIterator<'buf>) -> DCResult<'buf>,
     {
-        let (it, _cbor) = parser(self.decode_buf_iter.clone())?;
-        self.decode_buf_iter = it;
+        let (it, _cbor) = parser(self.decode_buf_iter.borrow().clone())?;
+        self.decode_buf_iter.replace(it);
         Ok(self)
     }
 
@@ -174,19 +503,14 @@ impl<'buf> CBORDecoder<'buf> {
     ///
     /// TODO: currently the lifetime management does not allow assignment of references to `self`
     /// within the `closure`.
-    pub fn cond<F, C>(
-        &mut self,
-        condition: bool,
-        parser: F,
-        closure: C,
-    ) -> Result<&mut Self, CBORError>
+    pub fn cond<F, C>(&self, condition: bool, parser: F, closure: C) -> Result<&Self, CBORError>
     where
         F: Fn(DecodeBufIterator<'buf>) -> DCResult<'buf>,
         C: Fn(CBOR<'buf>) -> Result<(), CBORError>,
     {
         if condition {
-            let (it, opt_cbor) = opt(&parser)(self.decode_buf_iter.clone())?;
-            self.decode_buf_iter = it;
+            let (it, opt_cbor) = opt(&parser)(self.decode_buf_iter.borrow().clone())?;
+            self.decode_buf_iter.replace(it);
             if let Some(cbor) = opt_cbor {
                 closure(cbor)?;
             }
@@ -203,12 +527,12 @@ impl<'buf> CBORDecoder<'buf> {
     /// TODO: currently the lifetime management does not allow assignment of references to `self`
     /// within the `closure`.
     pub fn range<F, C>(
-        &mut self,
+        &self,
         min: usize,
         max: usize,
         parser: F,
         mut closure: C,
-    ) -> Result<&mut Self, CBORError>
+    ) -> Result<&Self, CBORError>
     where
         F: Fn(DecodeBufIterator<'buf>) -> DCResult<'buf>,
         C: FnMut(usize, CBOR<'buf>) -> Result<(), CBORError>,
@@ -217,8 +541,8 @@ impl<'buf> CBORDecoder<'buf> {
 
         loop {
             // Have to borrow parser here because we call many times.
-            let (it, opt_cbor) = opt(&parser)(self.decode_buf_iter.clone())?;
-            self.decode_buf_iter = it;
+            let (it, opt_cbor) = opt(&parser)(self.decode_buf_iter.borrow().clone())?;
+            self.decode_buf_iter.replace(it);
             if let Some(cbor) = opt_cbor {
                 no_parse += 1;
                 closure(no_parse, cbor)?;
@@ -244,13 +568,17 @@ impl<'buf> CBORDecoder<'buf> {
     ///
     /// The `closure` function takes a `usize` for the iteration number and a `cbor` for the
     /// result of the parse.
-    pub fn many0<F, C>(&mut self, parser: F, closure: C) -> Result<&mut Self, CBORError>
+    pub fn many0<F, C>(&self, parser: F, closure: C) -> Result<&Self, CBORError>
     where
         F: Fn(DecodeBufIterator<'buf>) -> DCResult<'buf>,
-        C: FnMut(usize, CBOR<'buf>) -> Result<(), CBORError>
+        C: FnMut(usize, CBOR<'buf>) -> Result<(), CBORError>,
     {
         self.range(0, usize::MAX, parser, closure)
     }
+}
+
+pub trait CBORDecodable<'t> {
+    fn decode(&'t mut self, buf: &CBORDecoder) -> Result<&CBORDecoder, CBORError>;
 }
 
 /***************************************************************************************************
@@ -442,30 +770,6 @@ impl<'buf, O1, O2: From<O1>, F: DecodeParser<'buf, O1>> DecodeParser<'buf, O2> f
  * CBOR decoding combinators
  **************************************************************************************************/
 
-/// Match any CBOR type
-#[cfg(feature = "combinators")]
-pub fn is_any<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
-    move |mut iter| {
-        let item = iter.next();
-        match item {
-            Some(v) => Ok((iter, v)),
-            None => Err(CBORError::EndOfBuffer),
-        }
-    }
-}
-
-/// Match the end of the CBOR decode buffer
-#[cfg(feature = "combinators")]
-pub fn is_eof<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
-    move |mut iter| {
-        let item = iter.next();
-        match item {
-            Some(_) => Err(CBORError::EofExpected),
-            None => Ok((iter, CBOR::Eof)),
-        }
-    }
-}
-
 /// Match a CBOR positive integer
 #[cfg(feature = "combinators")]
 pub fn is_uint<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
@@ -479,23 +783,17 @@ pub fn is_uint<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
     }
 }
 
-/// Match a CBOR negative integer
+/// Match a CBOR positive integer
 #[cfg(feature = "combinators")]
 pub fn is_nint<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
     move |mut iter| {
         let item = iter.next();
         match item {
             Some(cbor @ CBOR::NInt(_)) => Ok((iter, cbor)),
-            Some(_) => Err(CBORError::ExpectedType("nint")),
+            Some(_) => Err(CBORError::ExpectedType("uint")),
             None => Err(CBORError::EndOfBuffer),
         }
     }
-}
-
-/// Match a CBOR integer
-#[cfg(feature = "combinators")]
-pub fn is_int<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
-    move |iter| DecodeParser::or(is_uint(), is_int()).parse(iter)
 }
 
 /// Match a CBOR bytestring
@@ -511,7 +809,7 @@ pub fn is_bstr<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
     }
 }
 
-/// Match a CBOR bytestring
+/// Match a CBOR text string
 #[cfg(feature = "combinators")]
 pub fn is_tstr<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
     move |mut iter| {
@@ -519,72 +817,6 @@ pub fn is_tstr<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
         match item {
             Some(cbor @ CBOR::Tstr(_)) => Ok((iter, cbor)),
             Some(_) => Err(CBORError::ExpectedType("tstr")),
-            None => Err(CBORError::EndOfBuffer),
-        }
-    }
-}
-
-/// Match a CBOR `false` value
-#[cfg(feature = "combinators")]
-pub fn is_false<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
-    move |mut iter| {
-        let item = iter.next();
-        match item {
-            Some(cbor @ CBOR::False) => Ok((iter, cbor)),
-            Some(_) => Err(CBORError::ExpectedType("false")),
-            None => Err(CBORError::EndOfBuffer),
-        }
-    }
-}
-
-/// Match a CBOR `true` value
-#[cfg(feature = "combinators")]
-pub fn is_true<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
-    move |mut iter| {
-        let item = iter.next();
-        match item {
-            Some(cbor @ CBOR::True) => Ok((iter, cbor)),
-            Some(_) => Err(CBORError::ExpectedType("true")),
-            None => Err(CBORError::EndOfBuffer),
-        }
-    }
-}
-
-/// Match a CBOR `bool` value
-#[cfg(feature = "combinators")]
-pub fn is_bool<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
-    move |mut iter| {
-        let item = iter.next();
-        match item {
-            Some(cbor @ CBOR::True) => Ok((iter, cbor)),
-            Some(cbor @ CBOR::False) => Ok((iter, cbor)),
-            Some(_) => Err(CBORError::ExpectedType("bool")),
-            None => Err(CBORError::EndOfBuffer),
-        }
-    }
-}
-
-/// Match a CBOR `null` value
-#[cfg(feature = "combinators")]
-pub fn is_null<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
-    move |mut iter| {
-        let item = iter.next();
-        match item {
-            Some(cbor @ CBOR::Null) => Ok((iter, cbor)),
-            Some(_) => Err(CBORError::ExpectedType("null")),
-            None => Err(CBORError::EndOfBuffer),
-        }
-    }
-}
-
-/// Match a CBOR `undefined` value
-#[cfg(feature = "combinators")]
-pub fn is_undefined<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
-    move |mut iter| {
-        let item = iter.next();
-        match item {
-            Some(cbor @ CBOR::Undefined) => Ok((iter, cbor)),
-            Some(_) => Err(CBORError::ExpectedType("undefined")),
             None => Err(CBORError::EndOfBuffer),
         }
     }
@@ -598,12 +830,12 @@ pub fn is_simple<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
         match item {
             Some(cbor @ CBOR::Simple(_)) => Ok((iter, cbor)),
             Some(_) => Err(CBORError::ExpectedType("simple")),
-            None => Err(CBORError::EndOfBuffer),
+            None => Err(CBORError::EndOfBuffer)
         }
     }
 }
 
-/// Match a CBOR array
+/// Match a CBOR `Array` value
 #[cfg(feature = "combinators")]
 pub fn is_array<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
     move |mut iter| {
@@ -611,12 +843,12 @@ pub fn is_array<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
         match item {
             Some(cbor @ CBOR::Array(_)) => Ok((iter, cbor)),
             Some(_) => Err(CBORError::ExpectedType("array")),
-            None => Err(CBORError::EndOfBuffer),
+            None => Err(CBORError::EndOfBuffer)
         }
     }
 }
 
-/// Match a CBOR map
+/// Match a CBOR `Map` value
 #[cfg(feature = "combinators")]
 pub fn is_map<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
     move |mut iter| {
@@ -624,6 +856,84 @@ pub fn is_map<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
         match item {
             Some(cbor @ CBOR::Map(_)) => Ok((iter, cbor)),
             Some(_) => Err(CBORError::ExpectedType("map")),
+            None => Err(CBORError::EndOfBuffer)
+        }
+    }
+}
+
+/// Match a CBOR `true` value
+#[cfg(feature = "combinators")]
+pub fn is_true<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::True) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("true")),
+            None => Err(CBORError::EndOfBuffer)
+        }
+    }
+}
+
+/// Match a CBOR `false` value
+#[cfg(feature = "combinators")]
+pub fn is_false<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::False) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("false")),
+            None => Err(CBORError::EndOfBuffer)
+        }
+    }
+}
+
+/// Match a CBOR `false` value
+#[cfg(feature = "combinators")]
+pub fn is_null<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::Null) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("null")),
+            None => Err(CBORError::EndOfBuffer)
+        }
+    }
+}
+
+/// Match a CBOR `false` value
+#[cfg(feature = "combinators")]
+pub fn is_undefined<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(cbor @ CBOR::Undefined) => Ok((iter, cbor)),
+            Some(_) => Err(CBORError::ExpectedType("undefined")),
+            None => Err(CBORError::EndOfBuffer)
+        }
+    }
+}
+
+/// Match a CBOR integer
+#[cfg(feature = "combinators")]
+pub fn is_int<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |iter| DecodeParser::or(is_uint(), is_nint()).parse(iter)
+}
+
+#[cfg(feature = "combinators")]
+pub fn is_bool<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |iter| match decode_bool()(iter)? {
+        (it, false) => Ok((it, CBOR::False)),
+        (it, true) => Ok((it, CBOR::True)),
+    }
+}
+
+/// Match any CBOR type
+#[cfg(feature = "combinators")]
+pub fn is_any<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(v) => Ok((iter, v)),
             None => Err(CBORError::EndOfBuffer),
         }
     }
@@ -683,10 +993,12 @@ pub fn is_date_time<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf
 #[cfg_attr(feature = "trace", trace)]
 #[cfg(any(test, all(feature = "combinators", feature = "full")))]
 pub fn is_epoch<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    use core::convert::TryInto;
+
     is_tag_helper(1, |iter| {
         let (_, cbor) = is_any()(iter)?;
         match cbor {
-            CBOR::UInt(_) | CBOR::NInt(_) => Ok(CBOR::Epoch(cbor.try_into_i64()?)),
+            CBOR::UInt(_) | CBOR::NInt(_) => Ok(CBOR::Epoch(cbor.try_into()?)),
             _ => Err(CBORError::ExpectedType("uint/nint")),
         }
     })
@@ -708,6 +1020,172 @@ where
                     Err(CBORError::ExpectedTag(tag))
                 }
             }
+            Some(_) => Err(CBORError::ExpectedType("tag")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Match the end of the CBOR decode buffer
+#[cfg(feature = "combinators")]
+pub fn is_eof<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCResult<'buf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(_) => Err(CBORError::EofExpected),
+            None => Ok((iter, CBOR::Eof)),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Decoders start here
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Decode a CBOR positive integer
+#[cfg(feature = "combinators")]
+pub fn decode_uint<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, i128> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(CBOR::UInt(v)) => Ok((iter, v as i128)),
+            Some(_) => Err(CBORError::ExpectedType("uint")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Decode a CBOR negative integer
+#[cfg(feature = "combinators")]
+pub fn decode_nint<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, i128> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(CBOR::NInt(v)) => Ok((iter, -1 - (v as i128))),
+            Some(_) => Err(CBORError::ExpectedType("nint")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Decode a CBOR integer
+#[cfg(feature = "combinators")]
+pub fn decode_int<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, i128> {
+    move |iter| DecodeParser::or(decode_uint(), decode_nint()).parse(iter)
+}
+
+/// Decode a CBOR bytestring
+#[cfg(feature = "combinators")]
+pub fn decode_bstr<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, &[u8]> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(CBOR::Bstr(bs)) => Ok((iter, bs)),
+            Some(_) => Err(CBORError::ExpectedType("bstr")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Decode a CBOR bytestring
+#[cfg(feature = "combinators")]
+pub fn decode_tstr<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, &str> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(CBOR::Tstr(ts)) => Ok((iter, ts)),
+            Some(_) => Err(CBORError::ExpectedType("tstr")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Decode a CBOR `bool` value
+#[cfg(feature = "combinators")]
+pub fn decode_bool<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, bool> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(CBOR::True) => Ok((iter, true)),
+            Some(CBOR::False) => Ok((iter, false)),
+            Some(_) => Err(CBORError::ExpectedType("bool")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Decode a CBOR `null` value
+#[cfg(feature = "combinators")]
+pub fn decode_null<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, CBOR> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(CBOR::Null) => Ok((iter, CBOR::Null)),
+            Some(_) => Err(CBORError::ExpectedType("null")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Decode a CBOR `null` value
+#[cfg(feature = "combinators")]
+pub fn decode_undefined<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, CBOR> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(CBOR::Undefined) => Ok((iter, CBOR::Undefined)),
+            Some(_) => Err(CBORError::ExpectedType("undefined")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Decode a CBOR `null` value
+#[cfg(feature = "combinators")]
+pub fn decode_simple<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, u8> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(CBOR::Simple(v)) => Ok((iter, v)),
+            Some(_) => Err(CBORError::ExpectedType("simple")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Decode a CBOR array
+#[cfg(feature = "combinators")]
+pub fn decode_array<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, ArrayBuf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(CBOR::Array(ab)) => Ok((iter, ab)),
+            Some(_) => Err(CBORError::ExpectedType("array")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Decode a CBOR map
+#[cfg(feature = "combinators")]
+pub fn decode_map<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, MapBuf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(CBOR::Map(mb)) => Ok((iter, mb)),
+            Some(_) => Err(CBORError::ExpectedType("map")),
+            None => Err(CBORError::EndOfBuffer),
+        }
+    }
+}
+
+/// Decode a CBOR tag
+#[cfg(feature = "combinators")]
+pub fn decode_tag<'buf>() -> impl Fn(DecodeBufIterator<'buf>) -> DCPResult<'buf, TagBuf> {
+    move |mut iter| {
+        let item = iter.next();
+        match item {
+            Some(CBOR::Tag(tb)) => Ok((iter, tb)),
             Some(_) => Err(CBORError::ExpectedType("tag")),
             None => Err(CBORError::EndOfBuffer),
         }

--- a/tps_minicbor/src/error.rs
+++ b/tps_minicbor/src/error.rs
@@ -64,6 +64,8 @@ pub enum CBORError {
     ExpectedTag(u64),
     #[cfg_attr(any(feature="full", test), error("Map does not contain the requested key"))]
     KeyNotPresent,
+    #[cfg_attr(any(feature="full", test), error("Array index out of bounds"))]
+    IndexOutOfBounds,
     #[cfg_attr(any(feature="full", test), error("Map does not contain a value for the found key"))]
     ValueNotPresent,
     #[cfg_attr(any(feature="full", test), error("Range underflow"))]

--- a/tps_minicbor/src/lib.rs
+++ b/tps_minicbor/src/lib.rs
@@ -46,9 +46,9 @@ extern crate half;
 #[cfg(any(feature = "full", test))]
 extern crate chrono;
 
-mod cbor_diag;
 pub(crate) mod array;
 pub(crate) mod ast;
+mod cbor_diag;
 pub(crate) mod constants;
 pub(crate) mod decode;
 pub(crate) mod decode_combinators;
@@ -60,8 +60,8 @@ pub(crate) mod utils;
 pub mod error;
 
 pub mod types {
-    pub use super::ast::CBOR;
     pub use super::array::array;
+    pub use super::ast::CBOR;
     pub use super::map::map;
     pub use super::tag::tag;
 }
@@ -76,9 +76,11 @@ pub mod decoder {
     // Decode Combinators API
     #[cfg(any(feature = "combinators", test))]
     pub use super::decode_combinators::{
-        apply, cond, is_any, is_array, is_bool, is_bstr, is_eof, is_false, is_int, is_map, is_nint,
-        is_null, is_simple, is_tag, is_tag_with_value, is_true, is_tstr, is_uint, is_undefined,
-        opt, or, with_pred, with_value, CBORDecoder,
+        apply, cond, decode_bool, decode_bstr, decode_int, decode_nint, decode_null,
+        decode_simple, decode_tstr, decode_uint, decode_undefined, is_any, is_array, is_bool,
+        is_bstr, is_eof, is_false, is_int, is_map, is_nint, is_null, is_simple, is_tag,
+        is_tag_with_value, is_true, is_tstr, is_uint, is_undefined, opt, or, with_pred,
+        with_value, CBORDecodable, CBORDecoder,
     };
 
     #[cfg(any(feature = "combinators", test))]
@@ -98,7 +100,7 @@ pub mod encoder {
 #[cfg(any(feature = "full", test))]
 pub mod debug {
     #[cfg(any(feature = "full", test))]
-    pub use super::cbor_diag::Diag;
-    #[cfg(any(feature = "full", test))]
     pub use super::cbor_diag::print_hex;
+    #[cfg(any(feature = "full", test))]
+    pub use super::cbor_diag::Diag;
 }

--- a/tps_minicbor/tests/adversarial_bugfix.rs
+++ b/tps_minicbor/tests/adversarial_bugfix.rs
@@ -1,5 +1,5 @@
 /***************************************************************************************************
- * Copyright (c) 2021 Jeremy O'Donoghue. All rights reserved.
+ * Copyright (c) 2020-2022 Qualcomm Innovation Center, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
  * and associated documentation files (the “Software”), to deal in the Software without
@@ -16,16 +16,29 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  **************************************************************************************************/
+/***************************************************************************************************
+ * Test cases for tps_minicbor: bugfixes and adversarial cases
+ **************************************************************************************************/
+extern crate tps_minicbor;
 
-use tps_cddl::cddl::CDDLParseError;
-use thiserror::Error;
+use tps_minicbor::encoder::*;
+use tps_minicbor::error::CBORError;
+use tps_minicbor::types::{array};
 
-#[derive(Debug, Error)]
-pub enum CddlError {
-    #[error("CDDL Parsing Error: {0}")]
-    CddlParseError(CDDLParseError),
-    #[error("Value has already been assigned. to {0}. Reassignment not allowed")]
-    ReassignmentError(String),
-    #[error("Fatal runtime error")]
-    FatalError
+/*
+ * This test case checks that the first entry in an array can be another array
+ */
+#[test]
+fn encode_nested_array_first_item_bugfix() -> Result<(), CBORError> {
+    println!("<=================== rfc8949_encode_nested_array ===================>");
+    let mut buffer = [0u8; 64];
+    let expected: &[u8] = &[0x82, 0x82, 0x01, 0x02, 0x82, 0x03, 0x04];
+
+    let mut encoder = CBORBuilder::new(&mut buffer);
+    let _ = encoder.insert(&array(|buff| {
+        buff.insert(&array(|buff| buff.insert(&1u8)?.insert(&2u8)))?
+            .insert(&array(|buff| buff.insert(&3u8)?.insert(&4u8)))
+    }))?;
+    assert_eq!(encoder.encoded()?, expected);
+    Ok(())
 }

--- a/tps_minicbor/tests/encode_decode_examples.rs
+++ b/tps_minicbor/tests/encode_decode_examples.rs
@@ -1,0 +1,307 @@
+/***************************************************************************************************
+ * Copyright (c) 2020-2022 Qualcomm Innovation Center, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * Test cases from RFC8949, for encoding using the high-level API (recommended)
+ *
+ * Test cases from RFC8949, Table 6.
+ **************************************************************************************************/
+
+extern crate tps_minicbor;
+
+use std::convert::TryFrom;
+
+use tps_minicbor::decoder::*;
+use tps_minicbor::encoder::*;
+use tps_minicbor::error::CBORError;
+use tps_minicbor::types::{array, map, tag, CBOR};
+
+#[test]
+fn encode_decode_cbor_ast() -> Result<(), CBORError> {
+    // Encode-decode round trip test
+    println!("<======================= encode_decode_cbor_ast =====================>");
+    let mut bytes = [0u8; 128];
+
+    {
+        let val: &[u8] = &[1, 2, 3, 4];
+
+        // values
+        let s1 = CBOR::Simple(17);
+        let s2 = CBOR::Simple(234);
+        let s3 = CBOR::False;
+        let tval = CBOR::UInt(0x5a5a5a5a5a5a);
+        let aval1 = CBOR::Tstr("usine à gaz");
+        let aval2 = CBOR::UInt(42);
+        let aval3 = CBOR::Undefined;
+        let mkey1 = CBOR::UInt(1);
+        let mval1 = CBOR::UInt(1023);
+        let mkey2 = CBOR::UInt(2);
+        let mval2 = CBOR::UInt(1025);
+        let mkey3 = CBOR::NInt(1);
+        let mval3 = CBOR::NInt(1024);
+        let mut tag_val: u64 = 0;
+
+        let mut encoded_cbor = CBORBuilder::new(&mut bytes);
+        encoded_cbor
+            .insert(&32u8)?
+            .insert(&(-(0xa5a5a5i32)))?
+            .insert(&"新年快乐")?
+            .insert(&val)?
+            .insert(&s1)?
+            .insert(&s2)?
+            .insert(&s3)?
+            .insert(&tag(37, |buf| buf.insert(&tval)))?
+            .insert(&array(|buf| {
+                buf.insert(&"usine à gaz")?
+                    .insert(&42u8)?
+                    .insert(&CBOR::Undefined)
+            }))?
+            .insert(&map(|buf| {
+                buf.insert_key_value(&1u8, &1023u32)?
+                    .insert_key_value(&2u8, &1025u32)?
+                    .insert_key_value(&(-1i8), &(-1024i32))
+            }))?;
+
+        let _decoder = CBORDecoder::new(encoded_cbor.build()?)
+            .decode_with(is_uint(), |cbor| {
+                Ok(assert_eq!(u32::try_from(cbor)?, 32u32))
+            })?
+            .decode_with(is_nint(), |cbor| {
+                Ok(assert_eq!(i32::try_from(cbor)?, -(0xa5a5a5i32)))
+            })?
+            .decode_with(is_tstr(), |cbor| {
+                Ok(assert_eq!(<&str>::try_from(cbor)?, "新年快乐"))
+            })?
+            .decode_with(is_bstr(), |cbor| {
+                Ok(assert_eq!(<&[u8]>::try_from(cbor)?, val))
+            })?
+            .decode_with(is_simple(), |cbor| Ok(assert_eq!(cbor, s1)))?
+            .decode_with(is_simple(), |cbor| Ok(assert_eq!(cbor, s2)))?
+            .decode_with(is_false(), |cbor| Ok(assert_eq!(cbor, s3)))?
+            .decode_with(is_tag(), |cbor| {
+                CBORDecoder::from_tag(cbor, &mut tag_val)?
+                    .decode_with(is_uint(), |cbor| Ok(assert_eq!(cbor, tval)))?
+                    .finalize()
+            })?
+            .decode_with(is_array(), |cbor| {
+                CBORDecoder::from_array(cbor)?
+                    .decode_with(is_tstr(), |cbor| Ok(assert_eq!(cbor, aval1)))?
+                    .decode_with(is_uint(), |cbor| Ok(assert_eq!(cbor, aval2)))?
+                    .decode_with(is_undefined(), |cbor| Ok(assert_eq!(cbor, aval3)))?
+                    .finalize()
+            })?
+            .decode_with(is_map(), |cbor| {
+                if let CBOR::Map(mb) = cbor {
+                    // In the test cases we do not care about the results of these - the assert_eq!()
+                    // tell us all we need.
+                    let _ = mb.get(&mkey1).map_or_else(
+                        || Err(CBORError::KeyNotPresent),
+                        |v| Ok(assert_eq!(v, mval1)),
+                    );
+                    let _ = mb.get(&mkey2).map_or_else(
+                        || Err(CBORError::KeyNotPresent),
+                        |v| Ok(assert_eq!(v, mval2)),
+                    );
+                    let _ = mb.get(&mkey3).map_or_else(
+                        || Err(CBORError::KeyNotPresent),
+                        |v| Ok(assert_eq!(v, mval3)),
+                    );
+                    Ok(())
+                } else {
+                    Err(CBORError::ExpectedType("Map"))
+                }
+            })?;
+    }
+    Ok(())
+}
+
+// / This is an example of a token produced by a HW block            /
+// / purpose-built for attestation.  Only the nonce claim changes    /
+// / from one attestation to the next as the rest  either come       /
+// / directly from the hardware or from one-time-programmable memory /
+// / (e.g. a fuse). 47 bytes encoded in CBOR (8 byte nonce, 16 byte  /
+// / UEID). /
+//
+// {
+// / nonce /           10: h'948f8860d13a463e',
+// / UEID /           256: h'0198f50a4ff6c05861c8860d13a638ea',
+// / OEMID /          258: 64242, / Private Enterprise Number /
+// / security-level / 261: 3, / hardware level security /
+// / secure-boot /    262: true,
+// / debug-status /   263: 3, / disabled-permanently /
+// / HW version /     260: [ "3.1", 1 ] / Type is multipartnumeric /
+// }
+#[test]
+fn encode_tee_eat() -> Result<(), CBORError> {
+    // Encode-decode round trip test
+    println!("<========================== encode_tee_eat =========================>");
+    let mut bytes = [0u8; 1024];
+    let expected: &[u8] = &[
+        167, 10, 72, 148, 143, 136, 96, 209, 58, 70, 62, 25, 1, 0, 80, 1, 152, 245, 10, 79, 246,
+        192, 88, 97, 200, 134, 13, 19, 166, 56, 234, 25, 1, 2, 25, 250, 242, 25, 1, 5, 3, 25, 1, 6,
+        245, 25, 1, 7, 3, 25, 1, 4, 130, 99, 51, 46, 49, 1,
+    ];
+    let nonce: &[u8] = &[0x94, 0x8f, 0x88, 0x60, 0xd1, 0x3a, 0x46, 0x3e];
+    let ueid: &[u8] = &[
+        0x01, 0x98, 0xf5, 0x0a, 0x4f, 0xf6, 0xc0, 0x58, 0x61, 0xc8, 0x86, 0x0d, 0x13, 0xa6, 0x38,
+        0xea,
+    ];
+
+    let mut encoded_cbor = CBORBuilder::new(&mut bytes);
+    encoded_cbor.insert(&map(|buff| {
+        buff.insert_key_value(&10, &nonce)?
+            .insert_key_value(&256, &ueid)?
+            .insert_key_value(&258, &64242)?
+            .insert_key_value(&261, &3)?
+            .insert_key_value(&262, &true)?
+            .insert_key_value(&263, &3)?
+            .insert_key_value(&260, &array(|buf| buf.insert(&"3.1")?.insert(&1)))
+    }))?;
+
+    assert_eq!(encoded_cbor.encoded()?, expected);
+    Ok(())
+}
+
+// / This is an example of a token produced by a HW block            /
+// / purpose-built for attestation.  Only the nonce claim changes    /
+// / from one attestation to the next as the rest  either come       /
+// / directly from the hardware or from one-time-programmable memory /
+// / (e.g. a fuse). 47 bytes encoded in CBOR (8 byte nonce, 16 byte  /
+// / UEID). /
+//
+// {
+// / nonce /           10: h'948f8860d13a463e',
+// / UEID /           256: h'0198f50a4ff6c05861c8860d13a638ea',
+// / OEMID /          258: 64242, / Private Enterprise Number /
+// / security-level / 261: 3, / hardware level security /
+// / secure-boot /    262: true,
+// / debug-status /   263: 3, / disabled-permanently /
+// / HW version /     260: [ "3.1", 1 ] / Type is multipartnumeric /
+// }
+#[derive(Debug, Clone)]
+struct TeeEat<'t> {
+    pub nonce: &'t [u8],
+    pub ueid: &'t [u8],
+    pub oemid: u64,
+    pub sec_level: u64,
+    pub sec_boot: bool,
+    pub debug_status: u64,
+    pub hw_version: HwVersion<'t>,
+}
+
+#[derive(Debug, Clone)]
+struct HwVersion<'t> {
+    s: &'t str,
+    v: u64,
+}
+
+#[test]
+fn decode_tee_eat() -> Result<(), CBORError> {
+    let mut input: &[u8] = &[
+        167, 10, 72, 148, 143, 136, 96, 209, 58, 70, 62, 25, 1, 0, 80, 1, 152, 245, 10, 79, 246,
+        192, 88, 97, 200, 134, 13, 19, 166, 56, 234, 25, 1, 2, 25, 250, 242, 25, 1, 5, 3, 25, 1, 6,
+        245, 25, 1, 7, 3, 25, 1, 4, 130, 99, 51, 46, 49, 1,
+    ];
+    let mut vsn_string = String::new();
+    let mut token = TeeEat {
+        nonce: &[],
+        ueid: &[],
+        oemid: 0,
+        sec_level: 0,
+        sec_boot: false,
+        debug_status: 0,
+        hw_version: HwVersion { s: &"", v: 0},
+    };
+
+    let decoder = CBORDecoder::from_slice(&mut input);
+    {
+        let _d = decoder.map(|mb| {
+            token.nonce = mb.lookup(10)?;
+            token.ueid = mb.lookup(256)?;
+            token.oemid = mb.lookup(258)?;
+            token.sec_level = mb.lookup(261)?;
+            token.sec_boot = mb.lookup(262)?;
+            token.debug_status = mb.lookup(263)?;
+            let ab: ArrayBuf = mb.lookup(260)?;
+            // Any bstr or tstr needs to be deep copied somewhere that
+            // definitely lives longer than the closure if we wish to use it
+            // outside. Here we copy into a string which is inferred to outlive
+            // the closure.
+            vsn_string = String::from(ab.item::<&str>(0)?);
+            token.hw_version.s = &vsn_string;
+            token.hw_version.v = ab.item(1)?;
+            Ok(())
+        })?;
+    }
+
+    assert_eq!(
+        token.nonce,
+        &[0x94, 0x8f, 0x88, 0x60, 0xd1, 0x3a, 0x46, 0x3e]
+    );
+    assert_eq!(
+        token.ueid,
+        &[
+            0x01, 0x98, 0xf5, 0x0a, 0x4f, 0xf6, 0xc0, 0x58, 0x61, 0xc8, 0x86, 0x0d, 0x13, 0xa6,
+            0x38, 0xea
+        ]
+    );
+    assert_eq!(token.oemid, 64242);
+    assert_eq!(token.sec_level, 3);
+    assert_eq!(token.sec_boot, true);
+    assert_eq!(token.debug_status, 3);
+    assert_eq!(token.hw_version.s, "3.1");
+    assert_eq!(token.hw_version.v, 1);
+    Ok(())
+}
+
+#[test]
+fn foo() -> Result<(), CBORError> {
+    // Encode-decode round trip test
+    println!("<======================= encode_decode_cbor_ast =====================>");
+    let mut bytes = [0u8; 128];
+
+    {
+        let mut encoded_cbor = CBORBuilder::new(&mut bytes);
+        encoded_cbor
+            .insert(&32u8)?
+            .insert(&(-(0xa5a5a5i32)))?
+            .insert(&"新年快乐")?
+            .insert(&array(|buf| {
+                buf.insert(&42u8)?
+                    .insert(&CBOR::Undefined)
+            }))?;
+
+        let _decoder = CBORDecoder::new(encoded_cbor.build()?)
+            .decode_with(is_uint(), |cbor| {
+                Ok(assert_eq!(u32::try_from(cbor)?, 32u32))
+            })?
+            .decode_with(is_nint(), |cbor| {
+                Ok(assert_eq!(i32::try_from(cbor)?, -(0xa5a5a5i32)))
+            })?
+            .decode_with(is_tstr(), |cbor| {
+                Ok(assert_eq!(<&str>::try_from(cbor)?, "新年快乐"))
+            })?
+            .decode_with(is_array(), |cbor| {
+                CBORDecoder::from_array(cbor)?
+                    .decode_with(is_uint(), |cbor| Ok(assert_eq!(u8::try_from(cbor)?, 42)))?
+                    .decode_with(is_undefined(), |cbor| Ok(assert_eq!(cbor, CBOR::Undefined)))?
+                    .finalize()
+            })?;
+    }
+    Ok(())
+}

--- a/tps_minicbor/tests/rfc8949_decode_high_level.rs
+++ b/tps_minicbor/tests/rfc8949_decode_high_level.rs
@@ -1,0 +1,805 @@
+/***************************************************************************************************
+ * Copyright (c) 2020-2022 Qualcomm Innovation Center, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+/***************************************************************************************************
+ * Test cases from RFC8949, for decoding using the high-level API (recommended)
+ *
+ * Test cases from RFC8949, Table 6.
+ **************************************************************************************************/
+
+extern crate tps_minicbor;
+
+use tps_minicbor::decoder::*;
+use tps_minicbor::error::CBORError;
+use tps_minicbor::types::{CBOR};
+
+#[test]
+fn decode_combinators_basic() -> Result<(), CBORError> {
+    println!("<======================= test_decode_combinators =====================>");
+    {
+        // Test 1: two parsers in sequence
+        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8, 0x19, 0x03, 0xe9]).into_iter();
+        let (it, r1) = is_uint()(it)?;
+        let (_it, r2) = is_uint()(it)?;
+        assert!(r1 == CBOR::UInt(1000) && r2 == CBOR::UInt(1001));
+    }
+    {
+        // Test 2: cond
+        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8]).into_iter();
+        let (it, r1) = is_uint()(it)?;
+        let (_next, v) = cond(true, is_eof())(it)?;
+        assert!(r1 == CBOR::UInt(1000) && v == Some(CBOR::Eof));
+    }
+    {
+        // Test 3: opt. First parse succeeds, second is skipped
+        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8]).into_iter();
+        let (it, r1) = opt(is_uint())(it)?;
+        let (_it, r2) = opt(is_bool())(it)?;
+        assert!(r1 == Some(CBOR::UInt(1000)) && r2 == None);
+    }
+    {
+        // Test 4: with_pred, nesting of parsers, sequence of parsers
+        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8, 0x19, 0x03, 0xe9]).into_iter();
+        let (it, r1) = opt(with_pred(is_uint(), |v| {
+            if let CBOR::UInt(value) = *v {
+                value == 1000
+            } else {
+                false
+            }
+        }))(it)?;
+        let (_it, r2) = is_uint()(it)?;
+        assert!(r1 == Some(CBOR::UInt(1000)) && r2 == CBOR::UInt(1001))
+    }
+    {
+        // Test 4: with_pred, nesting of parsers, sequence of parsers
+        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8, 0x19, 0x03, 0xe9]).into_iter();
+        let (it, r1) = opt(with_value(is_uint(), CBOR::UInt(1000)))(it)?;
+        let (_it, r2) = is_uint()(it)?;
+        assert!(r1 == Some(CBOR::UInt(1000)) && r2 == CBOR::UInt(1001))
+    }
+    Ok(())
+}
+
+#[test]
+fn rfc8949_decode_zero() {
+    let zero = [0x00].as_slice();
+    {
+        // Coerce to u8
+        let mut result: u8 = 33;
+        let _ = CBORDecoder::from_slice(&zero).value(decode_int(), &mut result);
+        assert_eq!(result, 0);
+    }
+    {
+        // Coerce to u16
+        let mut result: u16 = 33;
+        let _ = CBORDecoder::from_slice(&zero).value(decode_int(), &mut result);
+        assert_eq!(result, 0);
+    }
+    {
+        // Coerce to u32
+        let mut result: u32 = 33;
+        let _ = CBORDecoder::from_slice(&zero).value(decode_int(), &mut result);
+        assert_eq!(result, 0);
+    }
+    {
+        // Coerce to u64
+        let mut result: u64 = 33;
+        let _ = CBORDecoder::from_slice(&zero).value(decode_int(), &mut result);
+        assert_eq!(result, 0);
+    }
+}
+
+#[test]
+fn rfc8949_decode_one() {
+    let one = [0x01].as_slice();
+    {
+        // Coerce to u8
+        let mut result: u8 = 33;
+        let _ = CBORDecoder::from_slice(&one).value(decode_int(), &mut result);
+        assert_eq!(result, 1);
+    }
+    {
+        // Coerce to u16
+        let mut result: u16 = 33;
+        let _ = CBORDecoder::from_slice(&one).value(decode_int(), &mut result);
+        assert_eq!(result, 1);
+    }
+    {
+        // Coerce to u32
+        let mut result: u32 = 33;
+        let _ = CBORDecoder::from_slice(&one).value(decode_int(), &mut result);
+        assert_eq!(result, 1);
+    }
+    {
+        // Coerce to u64
+        let mut result: u64 = 33;
+        let _ = CBORDecoder::from_slice(&one).value(decode_int(), &mut result);
+        assert_eq!(result, 1);
+    }
+}
+
+#[test]
+fn rfc8949_decode_ten() {
+    let ten = [0x0a].as_slice();
+    {
+        // Coerce to u8
+        let mut result: u8 = 33;
+        let _ = CBORDecoder::from_slice(&ten).value(decode_int(), &mut result);
+        assert_eq!(result, 10);
+    }
+    {
+        // Coerce to u16
+        let mut result: u16 = 33;
+        let _ = CBORDecoder::from_slice(&ten).value(decode_int(), &mut result);
+        assert_eq!(result, 10);
+    }
+    {
+        // Coerce to u32
+        let mut result: u32 = 33;
+        let _ = CBORDecoder::from_slice(&ten).value(decode_int(), &mut result);
+        assert_eq!(result, 10);
+    }
+    {
+        // Coerce to u64
+        let mut result: u64 = 33;
+        let _ = CBORDecoder::from_slice(&ten).value(decode_int(), &mut result);
+        assert_eq!(result, 10);
+    }
+}
+
+#[test]
+fn rfc8949_decode_twenty_three() {
+    let twenty_three = [0x17].as_slice();
+    {
+        // Coerce to u8
+        let mut result: u8 = 33;
+        let _ = CBORDecoder::from_slice(&twenty_three).value(decode_int(), &mut result);
+        assert_eq!(result, 23);
+    }
+    {
+        // Coerce to u16
+        let mut result: u16 = 33;
+        let _ = CBORDecoder::from_slice(&twenty_three).value(decode_int(), &mut result);
+        assert_eq!(result, 23);
+    }
+    {
+        // Coerce to u32
+        let mut result: u32 = 33;
+        let _ = CBORDecoder::from_slice(&twenty_three).value(decode_int(), &mut result);
+        assert_eq!(result, 23);
+    }
+    {
+        // Coerce to u64
+        let mut result: u64 = 33;
+        let _ = CBORDecoder::from_slice(&twenty_three).value(decode_int(), &mut result);
+        assert_eq!(result, 23);
+    }
+}
+
+#[test]
+fn rfc8949_decode_twenty_four() {
+    let twenty_four = [0x18, 0x18].as_slice();
+    {
+        // Coerce to u8
+        let mut result: u8 = 33;
+        let _ = CBORDecoder::from_slice(&twenty_four).value(decode_int(), &mut result);
+        assert_eq!(result, 24);
+    }
+    {
+        // Coerce to u16
+        let mut result: u16 = 33;
+        let _ = CBORDecoder::from_slice(&twenty_four).value(decode_int(), &mut result);
+        assert_eq!(result, 24);
+    }
+    {
+        // Coerce to u32
+        let mut result: u32 = 33;
+        let _ = CBORDecoder::from_slice(&twenty_four).value(decode_int(), &mut result);
+        assert_eq!(result, 24);
+    }
+    {
+        // Coerce to u64
+        let mut result: u64 = 33;
+        let _ = CBORDecoder::from_slice(&twenty_four).value(decode_int(), &mut result);
+        assert_eq!(result, 24);
+    }
+}
+
+#[test]
+fn rfc8949_decode_twenty_five() {
+    let twenty_five = [0x18, 0x19].as_slice();
+    {
+        // Coerce to u8
+        let mut result: u8 = 33;
+        let _ = CBORDecoder::from_slice(&twenty_five).value(decode_int(), &mut result);
+        assert_eq!(result, 25);
+    }
+    {
+        // Coerce to u16
+        let mut result: u16 = 33;
+        let _ = CBORDecoder::from_slice(&twenty_five).value(decode_int(), &mut result);
+        assert_eq!(result, 25);
+    }
+    {
+        // Coerce to u32
+        let mut result: u32 = 33;
+        let _ = CBORDecoder::from_slice(&twenty_five).value(decode_int(), &mut result);
+        assert_eq!(result, 25);
+    }
+    {
+        // Coerce to u64
+        let mut result: u64 = 33;
+        let _ = CBORDecoder::from_slice(&twenty_five).value(decode_int(), &mut result);
+        assert_eq!(result, 25);
+    }
+}
+
+#[test]
+fn rfc8949_decode_one_hundred() {
+    let one_hundred = [0x18, 0x64].as_slice();
+    {
+        // Coerce to u8
+        let mut result: u8 = 33;
+        let _ = CBORDecoder::from_slice(&one_hundred).value(decode_int(), &mut result);
+        assert_eq!(result, 100);
+    }
+    {
+        // Coerce to u16
+        let mut result: u16 = 33;
+        let _ = CBORDecoder::from_slice(&one_hundred).value(decode_int(), &mut result);
+        assert_eq!(result, 100);
+    }
+    {
+        // Coerce to u32
+        let mut result: u32 = 33;
+        let _ = CBORDecoder::from_slice(&one_hundred).value(decode_int(), &mut result);
+        assert_eq!(result, 100);
+    }
+    {
+        // Coerce to u64
+        let mut result: u64 = 33;
+        let _ = CBORDecoder::from_slice(&one_hundred).value(decode_int(), &mut result);
+        assert_eq!(result, 100);
+    }
+}
+
+#[test]
+fn rfc8949_decode_one_thousand() {
+    let one_thousand = [0x19, 0x03, 0xe8].as_slice();
+    // u8 would be out of range (detected at comepile time)
+    {
+        // Coerce to u16
+        let mut result: u16 = 33;
+        let _ = CBORDecoder::from_slice(&one_thousand).value(decode_int(), &mut result);
+        assert_eq!(result, 1000);
+    }
+    {
+        // Coerce to u32
+        let mut result: u32 = 33;
+        let _ = CBORDecoder::from_slice(&one_thousand).value(decode_int(), &mut result);
+        assert_eq!(result, 1000);
+    }
+    {
+        // Coerce to u64
+        let mut result: u64 = 33;
+        let _ = CBORDecoder::from_slice(&one_thousand).value(decode_int(), &mut result);
+        assert_eq!(result, 1000);
+    }
+}
+
+#[test]
+fn rfc8949_decode_one_million() {
+    let one_million = [0x1a, 0x00, 0x0f, 0x42, 0x40].as_slice();
+    // u8 and u16 would be out of range (detected at comepile time)
+    {
+        // Coerce to u32
+        let mut result: u32 = 33;
+        let _ = CBORDecoder::from_slice(&one_million).value(decode_int(), &mut result);
+        assert_eq!(result, 1_000_000);
+    }
+    {
+        // Coerce to u64
+        let mut result: u64 = 33;
+        let _ = CBORDecoder::from_slice(&one_million).value(decode_int(), &mut result);
+        assert_eq!(result, 1_000_000);
+    }
+}
+
+#[test]
+fn rfc8949_decode_one_trillion() {
+    let one_trillion = [0x1b, 0x00, 0x00, 0x00, 0xe8, 0xd4, 0xa5, 0x10, 0x00].as_slice();
+    // u8, u16 and u32 would be out of range (detected at comepile time)
+    {
+        // Coerce to u64
+        let mut result: u64 = 33;
+        let _ = CBORDecoder::from_slice(&one_trillion).value(decode_int(), &mut result);
+        assert_eq!(result, 1_000_000_000_000);
+    }
+}
+
+#[test]
+fn rfc8949_decode_max_uint() {
+    let max_int = [0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff].as_slice();
+    // u8, u16 and u32 would be out of range (detected at comepile time)
+    {
+        // Coerce to u64
+        let mut result: u64 = 33;
+        let _ = CBORDecoder::from_slice(&max_int).value(decode_int(), &mut result);
+        assert_eq!(result, u64::MAX);
+    }
+}
+
+#[test]
+fn rfc8949_decode_minus_one() {
+    let minus_one = [0x20].as_slice();
+    {
+        // Coerce to i8
+        let mut result: i8 = 33;
+        let _ = CBORDecoder::from_slice(&minus_one).value(decode_nint(), &mut result);
+        assert_eq!(result, -1);
+    }
+    {
+        // Coerce to i16
+        let mut result: i16 = 33;
+        let _ = CBORDecoder::from_slice(&minus_one).value(decode_int(), &mut result);
+        assert_eq!(result, -1);
+    }
+    {
+        // Coerce to i32
+        let mut result: i32 = 33;
+        let _ = CBORDecoder::from_slice(&minus_one).value(decode_int(), &mut result);
+        assert_eq!(result, -1);
+    }
+    {
+        // Coerce to i64
+        let mut result: i64 = 33;
+        let _ = CBORDecoder::from_slice(&minus_one).value(decode_int(), &mut result);
+        assert_eq!(result, -1);
+    }
+}
+
+#[test]
+fn rfc8949_decode_minus_ten() {
+    let minus_ten = [0x29].as_slice();
+    {
+        // Coerce to i8
+        let mut result: i8 = 33;
+        let _ = CBORDecoder::from_slice(&minus_ten).value(decode_nint(), &mut result);
+        assert_eq!(result, -10);
+    }
+    {
+        // Coerce to i16
+        let mut result: i16 = 33;
+        let _ = CBORDecoder::from_slice(&minus_ten).value(decode_int(), &mut result);
+        assert_eq!(result, -10);
+    }
+    {
+        // Coerce to i32
+        let mut result: i32 = 33;
+        let _ = CBORDecoder::from_slice(&minus_ten).value(decode_int(), &mut result);
+        assert_eq!(result, -10);
+    }
+    {
+        // Coerce to i64
+        let mut result: i64 = 33;
+        let _ = CBORDecoder::from_slice(&minus_ten).value(decode_int(), &mut result);
+        assert_eq!(result, -10);
+    }
+}
+
+#[test]
+fn rfc8949_decode_minus_one_hundred() {
+    let minus_one_hundred = [0x38, 0x63].as_slice();
+    {
+        // Coerce to i8
+        let mut result: i8 = 33;
+        let _ = CBORDecoder::from_slice(&minus_one_hundred).value(decode_nint(), &mut result);
+        assert_eq!(result, -100);
+    }
+    {
+        // Coerce to i16
+        let mut result: i16 = 33;
+        let _ = CBORDecoder::from_slice(&minus_one_hundred).value(decode_int(), &mut result);
+        assert_eq!(result, -100);
+    }
+    {
+        // Coerce to i32
+        let mut result: i32 = 33;
+        let _ = CBORDecoder::from_slice(&minus_one_hundred).value(decode_int(), &mut result);
+        assert_eq!(result, -100);
+    }
+    {
+        // Coerce to i64
+        let mut result: i64 = 33;
+        let _ = CBORDecoder::from_slice(&minus_one_hundred).value(decode_int(), &mut result);
+        assert_eq!(result, -100);
+    }
+}
+
+#[test]
+fn rfc8949_decode_minus_one_thousand() {
+    let minus_one_thousand = [0x39, 0x03, 0xe7].as_slice();
+    // Out of range for i8
+    {
+        // Coerce to i16
+        let mut result: i16 = 33;
+        let _ = CBORDecoder::from_slice(&minus_one_thousand).value(decode_int(), &mut result);
+        assert_eq!(result, -1000);
+    }
+    {
+        // Coerce to i32
+        let mut result: i32 = 33;
+        let _ = CBORDecoder::from_slice(&minus_one_thousand).value(decode_int(), &mut result);
+        assert_eq!(result, -1000);
+    }
+    {
+        // Coerce to i64
+        let mut result: i64 = 33;
+        let _ = CBORDecoder::from_slice(&minus_one_thousand).value(decode_int(), &mut result);
+        assert_eq!(result, -1000);
+    }
+}
+
+#[test]
+fn rfc8949_decode_min_nint() {
+    let minus_one_thousand = [0x3b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff].as_slice();
+    // Out of range for i8, i16, i32
+    {
+        // Coerce to i128
+        let mut result: i128 = 33;
+        let _ = CBORDecoder::from_slice(&minus_one_thousand).value(decode_int(), &mut result);
+        assert_eq!(result, -18446744073709551616);
+    }
+}
+
+#[test]
+fn rfc8949_decode_simple() {
+    println!(
+        "<=============================== rfc8949_decode_simple_hl ============================>"
+    );
+    {
+        println!("<======================= Test with false =====================>");
+        let mut result = true;
+        let _ = CBORDecoder::from_slice(&[0xf4]).value(decode_bool(), &mut result);
+        assert_eq!(result, false);
+    }
+    {
+        println!("<======================= Test with true =====================>");
+        let mut result = false;
+        let _ = CBORDecoder::from_slice(&[0xf5]).value(decode_bool(), &mut result);
+        assert_eq!(result, true);
+    }
+    {
+        println!("<======================= Test with null =====================>");
+        let mut result = CBOR::Undefined;
+        let _ = CBORDecoder::from_slice(&[0xf6]).value(decode_null(), &mut result);
+        assert_eq!(result, CBOR::Null);
+    }
+    {
+        println!("<======================= Test with undefined =====================>");
+        let mut result = CBOR::Null;
+        let _ = CBORDecoder::from_slice(&[0xf7]).value(decode_undefined(), &mut result);
+        assert_eq!(result, CBOR::Undefined);
+    }
+    {
+        println!("<======================= Test with simple(16) =====================>");
+        let mut result = 1;
+        let _ = CBORDecoder::from_slice(&[0xf0]).value(decode_simple(), &mut result);
+        assert_eq!(result, 16);
+    }
+    {
+        println!("<======================= Test with simple(255) =====================>");
+        let mut result = 1;
+        let _ = CBORDecoder::from_slice(&[0xf8, 0xff]).value(decode_simple(), &mut result);
+        assert_eq!(result, 255);
+    }
+    {
+        println!(
+            "<======================= Test with simple(19), simple(253) =====================>"
+        );
+        let mut r1 = 0;
+        let mut r2 = 0;
+        let _ = CBORDecoder::from_slice(&[0xf3, 0xf8, 0xfd])
+            .value(decode_simple(), &mut r1)
+            .unwrap()
+            .value(decode_simple(), &mut r2);
+        assert_eq!(r1, 19);
+        assert_eq!(r2, 253);
+    }
+}
+
+#[test]
+fn rfc8949_decode_tstr() {
+    println!(
+        "<=============================== rfc8949_decode_tstr ==============================>"
+    );
+    {
+        // This is not nice, but easiest way to get a mutable &str which we can reassign
+        let mut result = "abc";
+        let _ = CBORDecoder::from_slice(&[0x60]).value(decode_tstr(), &mut result);
+        assert_eq!(result, "");
+    }
+    {
+        let mut result = "abc";
+        let _ = CBORDecoder::from_slice(&[0x61, 0x61]).value(decode_tstr(), &mut result);
+        assert_eq!(result, "a");
+    }
+    {
+        let mut result = "abc";
+        let _ = CBORDecoder::from_slice(&[0x64, 0x49, 0x45, 0x54, 0x46])
+            .value(decode_tstr(), &mut result);
+        assert_eq!(result, "IETF");
+    }
+    {
+        let mut result = "abc";
+        let _ = CBORDecoder::from_slice(&[0x62, 0x22, 0x5c]).value(decode_tstr(), &mut result);
+        assert_eq!(result, "\"\\");
+    }
+    {
+        let mut result = "abc";
+        let _ = CBORDecoder::from_slice(&[0x62, 0xc3, 0xbc]).value(decode_tstr(), &mut result);
+        assert_eq!(result, "\u{00fc}");
+    }
+    {
+        let mut result = "abc";
+        let _ =
+            CBORDecoder::from_slice(&[0x63, 0xe6, 0xb0, 0xb4]).value(decode_tstr(), &mut result);
+        assert_eq!(result, "\u{6c34}");
+    }
+    // The below is illegal as Rust requires chars to be Unicode scalar values
+    // which means that only values in 0x0..=0xd7ff and 0xe000..=0x10ffff are
+    // legal. In short, RFC8949 has an example which is not actually legal UTF8
+    // - see Unicode Standard, v12.0, Section 3.9, Table 3-7.
+    // [0x64, 0xf0, 0x90, 0x85, 0x91],  "\u{00d800}\u{00dd51}"
+}
+
+#[test]
+fn rfc8949_decode_bstr() {
+    println!(
+        "<=============================== rfc8949_decode_bstr ==============================>"
+    );
+    {
+        // This is not nice, but easiest way to get a mutable &[u8] slide which we can reassign
+        let mut result = [0x37].as_slice();
+        let _ = CBORDecoder::from_slice(&[0x40]).value(decode_bstr(), &mut result);
+        assert_eq!(result, &[]);
+    }
+    {
+        // This is not nice, but easiest way to get a mutable &[u8] slide which we can reassign
+        let mut result = [0x37].as_slice();
+        let _ = CBORDecoder::from_slice(&[0x44, 0x01, 0x02, 0x03, 0x04])
+            .value(decode_bstr(), &mut result);
+        assert_eq!(result, &[1, 2, 3, 4]);
+    }
+}
+
+#[test]
+fn rfc8949_decode_array() -> Result<(), CBORError> {
+    println!(
+        "<=============================== rfc8949_decode_array =============================>"
+    );
+    {
+        println!("<======================= Test with empty array =====================>");
+        let _decoder = CBORDecoder::from_slice(&[0x80]).array(|ab| {
+            assert_eq!(ab.len(), 0);
+            Ok(())
+        });
+    }
+    {
+        println!("<======================= Test with [1,2,3] =====================>");
+        let _ = CBORDecoder::from_slice(&[0x83, 0x01, 0x02, 0x03]).array(|ab| {
+            assert_eq!(ab.item::<u8>(2)?, 3u8);
+            assert_eq!(ab.item::<u8>(1)?, 2u8);
+            assert_eq!(ab.item::<u8>(0)?, 1u8);
+            Ok(())
+        });
+    }
+    {
+        println!("<======================= Test with [1,[2,3],[4,5]] =====================>");
+        // NB: the array items have to be coerced to the correct type
+        // - type inference doesn't work in this example
+        let _d = CBORDecoder::from_slice(&[0x83, 0x01, 0x82, 0x02, 0x03, 0x82, 0x04, 0x05]).array(
+            |ab| {
+                assert_eq!(ab.item::<u8>(0)?, 1u8);
+                let a1 = CBORDecoder::from_array(ab.item(1)?)?;
+                let _ = a1.array(|ab1| {
+                    assert_eq!(ab1.item::<u8>(1)?, 3u8);
+                    assert_eq!(ab1.item::<u8>(0)?, 2u8);
+                    Ok(())
+                });
+                let a2 = CBORDecoder::from_array(ab.item(2)?)?;
+                let _ = a2.array(|ab2| {
+                    assert_eq!(ab2.item::<u8>(1)?, 5u8);
+                    assert_eq!(ab2.item::<u8>(0)?, 4u8);
+                    Ok(())
+                });
+                Ok(())
+            },
+        );
+    }
+    {
+        println!("<======================= Test with [1,2, ..., 25] =====================>");
+        let _ = CBORDecoder::from_slice(&[
+            0x98, 0x19, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+            0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x18, 0x18,
+            0x19,
+        ])
+        .array(|ab| {
+            for i in 0..=ab.len() {
+                assert_eq!(ab.item::<u8>(i)?, i.clone() as u8 + 1);
+            }
+            Ok(())
+        });
+    }
+    {
+        println!(
+            "<======================= Test with [\"a\", (\"b\": \"c\")]  =====================>"
+        );
+        let _ = CBORDecoder::from_slice(&[0x82, 0x61, 0x61, 0xa1, 0x61, 0x62, 0x61, 0x63])
+            .array(|ab| {
+                assert_eq!(ab.len(), 2);
+                assert_eq!(ab.item::<&str>(0)?, "a");
+                let _ = CBORDecoder::from_map(ab.item(2)?)?
+                    .map(|mb| {
+                    assert_eq!(mb.lookup::<&str, &str>("b")?, "c");
+                    Ok(())
+                });
+                Ok(())
+            });
+    }
+    Ok(())
+}
+
+#[test]
+fn rfc8949_decode_map() -> Result<(), CBORError> {
+    println!("<=============================== rfc8949_decode_map =============================>");
+    {
+        println!("<======================= Test with empty map =====================>");
+        let _ = CBORDecoder::from_slice(&[0xa0])
+            .map(|mb| {
+                assert_eq!(mb.len(), 0);
+                assert!(mb.is_empty());
+                Ok(())
+            });
+    }
+    {
+        println!("<======================= Test with (1: 2, 3: 4)  =====================>");
+        let _ = CBORDecoder::from_slice(&[0xa2, 0x01, 0x02, 0x03, 0x04])
+            .map(|mb| {
+                assert_eq!(mb.len(), 2);
+                assert_eq!(mb.lookup::<u8, u8>(1)?, 2);
+                assert_eq!(mb.lookup::<u8, u8>(3)?, 4);
+                Ok(())
+            });
+    }
+    {
+        println!(
+            "<======================= Test with (\"a\": 1, \"b\": [2,3])  =====================>"
+        );
+        let _ = CBORDecoder::from_slice(&[0xa2, 0x61, 0x61, 0x01, 0x61, 0x62, 0x82, 0x02, 0x03])
+            .map(|mb| {
+                assert_eq!(mb.len(), 2);
+                assert_eq!(mb.lookup::<&str, u8>("a")?, 1);
+                let _a = CBORDecoder::from_map(mb.lookup("b")?)?
+                    .array(|ab| {
+                        assert_eq!(ab.item::<u8>(0)?, 2);
+                        assert_eq!(ab.item::<u8>(1)?, 3);
+                        Ok(())
+                    });
+                Ok(())
+            });
+    }
+    {
+        println!(
+            "<======================= Test with (\"a\": \"A\", \"b\": \"B\", \"c\": \"C\", \"d\": \"D\", \"e\": \"E\")  =====================>"
+        );
+        let _ = CBORDecoder::from_slice(&[
+            0xa5, 0x61, 0x61, 0x61, 0x41, 0x61, 0x62, 0x61, 0x42, 0x61, 0x63, 0x61, 0x43, 0x61,
+            0x64, 0x61, 0x44, 0x61, 0x65, 0x61, 0x45,
+        ])
+            .map(|mb| {
+                assert_eq!(mb.len(), 5);
+                assert_eq!(mb.lookup::<&str, &str>("a")?, "A");
+                assert_eq!(mb.lookup::<&str, &str>("e")?, "E");
+                assert_eq!(mb.lookup::<&str, &str>("b")?, "B");
+                assert_eq!(mb.lookup::<&str, &str>("d")?, "D");
+                assert_eq!(mb.lookup::<&str, &str>("c")?, "C");
+                Ok(())
+            });
+    }
+    Ok(())
+}
+
+#[test]
+fn rfc8949_decode_tag() -> Result<(), CBORError> {
+    println!("<=============================== rfc8949_decode_tag =============================>");
+    {
+        println!(
+            "<======================= Test with 0(\"2013-03-21T20:04:00Z\") =====================>"
+        );
+        let _ = CBORDecoder::from_slice(&[
+            0xc0, 0x74, 0x32, 0x30, 0x31, 0x33, 0x2d, 0x30, 0x33, 0x2d, 0x32, 0x31, 0x54, 0x32,
+            0x30, 0x3a, 0x30, 0x34, 0x3a, 0x30, 0x30, 0x5a,
+        ])
+            .tag(|tb|{
+                if tb.get_tag() == 0 {
+                    let result = tb.item::<&str>()?;
+                    assert_eq!(result, "2013-03-21T20:04:00Z");
+                } else {
+                    assert!(false);
+                }
+                Ok(())
+            })?;
+    }
+    {
+        println!("<======================= Test with 1(1363896240) =====================>");
+        let _ = CBORDecoder::from_slice(&[0xc1, 0x1a, 0x51, 0x4b, 0x67, 0xb0])
+            .tag(|tb| {
+                if tb.get_tag() == 1 {
+                    let result = tb.item::<u64>()?;
+                    assert_eq!(result, 1363896240);
+                } else {
+                    assert!(false)
+                }
+                Ok(())
+            })?;
+    }
+    {
+        println!("<======================= Test with 23(h'01020304') =====================>");
+        let _ = CBORDecoder::from_slice(&[0xd7, 0x44, 0x01, 0x02, 0x03, 0x04])
+            .tag(|tb| {
+                if tb.get_tag() == 23 {
+                    let result = tb.item::<&[u8]>()?;
+                    assert_eq!(result, &[1, 2, 3, 4]);
+                } else {
+                    assert!(false);
+                }
+                Ok(())
+            })?;
+    }
+    {
+        println!("<======================= Test with 24(h'6449455446') =====================>");
+        let _ = CBORDecoder::from_slice(&[0xd8, 0x18, 0x45, 0x64, 0x49, 0x45, 0x54, 0x46])
+            .tag(|tb| {
+                if tb.get_tag() == 24 {
+                    let result = tb.item::<&[u8]>()?;
+                    assert_eq!(result, &[0x64, 0x49, 0x45, 0x54, 0x46]);
+                } else {
+                    assert!(false)
+                }
+                Ok(())
+            })?;
+    }
+    {
+        println!("<======================= Test with 32(\"http://www.example.com\") =====================>");
+        let _ = CBORDecoder::from_slice(&[
+            0xd8, 0x20, 0x76, 0x68, 0x74, 0x74, 0x70, 0x3a, 0x2f, 0x2f, 0x77, 0x77, 0x77, 0x2e,
+            0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d,
+        ])
+            .tag(|tb| {
+                if tb.get_tag() == 32 {
+                    let result = tb.item::<&str>()?;
+                    assert_eq!(result, "http://www.example.com")
+                } else {
+                    assert!(false);
+                }
+                Ok(())
+            })?;
+    }
+    Ok(())
+}

--- a/tps_minicbor/tests/rfc8949_decode_low_level.rs
+++ b/tps_minicbor/tests/rfc8949_decode_low_level.rs
@@ -17,20 +17,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  **************************************************************************************************/
 /***************************************************************************************************
- * Test cases from RFC7049, for decoding
+ * Test cases from RFC8949, for decoding using the low level API (if highly memory constrained)
  *
- * Test cases from RFC7049, Table 4.
+ * Test cases from RFC8949, Table 6.
  **************************************************************************************************/
 
 extern crate tps_minicbor;
 
-use core::convert::TryFrom;
+use std::convert::TryFrom;
 use half::f16;
 
 use tps_minicbor::decoder::*;
-use tps_minicbor::error::CBORError;
 use tps_minicbor::types::CBOR;
 
+/***************************************************************************************************
+ * Test cases for basic decoding using low-level interfaces
+ **************************************************************************************************/
 macro_rules! check_int_result {
     ($result:expr, $expected:expr) => {
         if let Ok(value) = $result {
@@ -65,15 +67,15 @@ fn decode_single(buf: &[u8]) -> Option<CBOR> {
 // over/underflows are properly detected.
 fn decode_integer(buf: &[u8], expected_values: &[Option<i128>; 9]) {
     if let Some(item) = decode_single(buf) {
-        let u1 = u8::try_from(&item);
-        let u2 = u16::try_from(&item);
-        let u3 = u32::try_from(&item);
-        let u4 = u64::try_from(&item);
-        let s1 = i8::try_from(&item);
-        let s2 = i16::try_from(&item);
-        let s3 = i32::try_from(&item);
-        let s4 = i64::try_from(&item);
-        let s5 = i128::try_from(&item);
+        let u1 = u8::try_from(item);
+        let u2 = u16::try_from(item);
+        let u3 = u32::try_from(item);
+        let u4 = u64::try_from(item);
+        let s1 = i8::try_from(item);
+        let s2 = i16::try_from(item);
+        let s3 = i32::try_from(item);
+        let s4 = i64::try_from(item);
+        let s5 = i128::try_from(item);
 
         check_int_result!(u1, expected_values[0]);
         check_int_result!(u2, expected_values[1]);
@@ -121,12 +123,12 @@ fn decode_integer_array(buf: &[u8], expect: &[i128]) {
         for item in ab.into_iter() {
             match item {
                 CBOR::UInt(_) => {
-                    if let Ok(value) = i128::try_from(&item) {
+                    if let Ok(value) = i128::try_from(item) {
                         result.push(value)
                     }
                 }
                 CBOR::NInt(_) => {
-                    if let Ok(value) = i128::try_from(&item) {
+                    if let Ok(value) = i128::try_from(item) {
                         result.push(value)
                     }
                 }
@@ -140,9 +142,12 @@ fn decode_integer_array(buf: &[u8], expect: &[i128]) {
     }
 }
 
+/***************************************************************************************************
+ * Test cases from RFC8949
+ **************************************************************************************************/
 // Verify unsigned integer item decode using iterator API and <type>::try_from(&item) for all cases
 #[test]
-fn rfc8949_decode_uint_manual() {
+fn rfc8949_decode_uint() {
     println!("<======================= rfc8949_decode_uint =====================>");
 
     // Test1: 0
@@ -325,7 +330,7 @@ fn rfc8949_decode_uint_manual() {
 
 // Verify signed integer item decode using iterator API and <type>::try_from(&item) for all cases
 #[test]
-fn rfc8949_decode_sint_manual() {
+fn rfc8949_decode_sint() {
     println!("<======================= rfc8949_decode_sint =====================>");
 
     // Test1: -1
@@ -411,7 +416,7 @@ fn rfc8949_decode_sint_manual() {
 }
 
 #[test]
-fn rfc8949_decode_bs_manual() {
+fn rfc8949_decode_bs() {
     println!("<======================= rfc8949_decode_bs =====================>");
 
     // Test1: h''
@@ -423,7 +428,7 @@ fn rfc8949_decode_bs_manual() {
 }
 
 #[test]
-fn rfc8949_decode_str_manual() {
+fn rfc8949_decode_str() {
     println!("<======================= rfc8949_decode_str =====================>");
 
     // Test1: ""
@@ -455,7 +460,7 @@ fn rfc8949_decode_str_manual() {
 }
 
 #[test]
-fn rfc8949_decode_arr_manual() {
+fn rfc8949_decode_arr() {
     println!("<======================= rfc8949_decode_arr =====================>");
     // Test1: []
     println!("\n\nrfc8949_decode_arr - Test 1 - []");
@@ -479,7 +484,7 @@ fn rfc8949_decode_arr_manual() {
                 match (ab.index(i), i) {
                     // Expect first item to be UInt(1)
                     (Some(i @ CBOR::UInt(_)), 0) => {
-                        check_int_result!(u8::try_from(&i), Some(1))
+                        check_int_result!(u8::try_from(i), Some(1))
                     }
                     (Some(CBOR::Array(ab1)), 1) => {
                         println!("ab1: {:?}", ab1);
@@ -516,487 +521,7 @@ fn rfc8949_decode_arr_manual() {
 }
 
 #[test]
-fn decode_combinators_basic() -> Result<(), CBORError> {
-    println!("<======================= test_decode_combinators =====================>");
-    {
-        // Test 1: two parsers in sequence
-        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8, 0x19, 0x03, 0xe9]).into_iter();
-        let (it, r1) = is_uint()(it)?;
-        let (_it, r2) = is_uint()(it)?;
-        assert!(r1 == CBOR::UInt(1000) && r2 == CBOR::UInt(1001));
-    }
-    {
-        // Test 2: cond
-        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8]).into_iter();
-        let (it, r1) = is_uint()(it)?;
-        let (_next, v) = cond(true, is_eof())(it)?;
-        assert!(r1 == CBOR::UInt(1000) && v == Some(CBOR::Eof));
-    }
-    {
-        // Test 3: opt. First parse succeeds, second is skipped
-        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8]).into_iter();
-        let (it, r1) = opt(is_uint())(it)?;
-        let (_it, r2) = opt(is_bool())(it)?;
-        assert!(r1 == Some(CBOR::UInt(1000)) && r2 == None);
-    }
-    {
-        // Test 4: with_pred, nesting of parsers, sequence of parsers
-        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8, 0x19, 0x03, 0xe9]).into_iter();
-        let (it, r1) = opt(with_pred(is_uint(), |v| {
-            if let CBOR::UInt(value) = *v {
-                value == 1000
-            } else {
-                false
-            }
-        }))(it)?;
-        let (_it, r2) = is_uint()(it)?;
-        assert!(r1 == Some(CBOR::UInt(1000)) && r2 == CBOR::UInt(1001))
-    }
-    {
-        // Test 4: with_pred, nesting of parsers, sequence of parsers
-        let it = SequenceBuffer::new(&[0x19, 0x03, 0xe8, 0x19, 0x03, 0xe9]).into_iter();
-        let (it, r1) = opt(with_value(is_uint(), CBOR::UInt(1000)))(it)?;
-        let (_it, r2) = is_uint()(it)?;
-        assert!(r1 == Some(CBOR::UInt(1000)) && r2 == CBOR::UInt(1001))
-    }
-    Ok(())
-}
-
-#[test]
-fn rfc8949_decode_uint_with_combinator() -> Result<(), CBORError> {
-    fn decode_uint(seq: &[u8], v: u64) -> Result<(), CBORError> {
-        println!(
-            "<======================= Test with v = {} =====================>",
-            v
-        );
-        let it = SequenceBuffer::new(seq).into_iter();
-        let (_it, r1) = with_value(is_uint(), CBOR::UInt(v))(it)?;
-        println!("r1 = {:?}, v = {}", r1, v);
-        assert_eq!(r1, CBOR::UInt(v));
-        Ok(())
-    }
-    println!("<======================= rfc8949_decode_uint_with_combinator =====================>");
-    decode_uint(&[0x00], 0)?;
-    decode_uint(&[0x01], 1)?;
-    decode_uint(&[0x0a], 10)?;
-    decode_uint(&[0x17], 23)?;
-    decode_uint(&[0x18, 0x18], 24)?;
-    decode_uint(&[0x18, 0x19], 25)?;
-    decode_uint(&[0x18, 0x64], 100)?;
-    decode_uint(&[0x19, 0x03, 0xe8], 1000)?;
-    decode_uint(&[0x1a, 0x00, 0x0f, 0x42, 0x40], 1000000)?;
-    decode_uint(
-        &[0x1b, 0x00, 0x00, 0x00, 0xe8, 0xd4, 0xa5, 0x10, 0x00],
-        1000000000000,
-    )?;
-    decode_uint(
-        &[0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
-        18446744073709551615,
-    )?;
-    Ok(())
-}
-
-#[test]
-fn rfc8949_decode_nint_with_combinator() -> Result<(), CBORError> {
-    fn decode_nint(seq: &[u8], v: i128) -> Result<(), CBORError> {
-        println!(
-            "<======================= Test with v = {} =====================>",
-            v
-        );
-        let nint_repr: u64 = (-v - 1) as u64;
-        let it = SequenceBuffer::new(seq).into_iter();
-        let (_it, r1) = with_value(is_nint(), CBOR::NInt(nint_repr))(it)?;
-        println!("r1 = {:?}, v = {}, nint_repr = {}", r1, v, nint_repr);
-        assert_eq!(r1, CBOR::NInt(nint_repr));
-        Ok(())
-    }
-    println!("<======================= rfc8949_decode_nint_with_combinator =====================>");
-    decode_nint(&[0x20], -1)?;
-    decode_nint(&[0x29], -10)?;
-    decode_nint(&[0x38, 0x63], -100)?;
-    decode_nint(&[0x39, 0x03, 0xe7], -1000)?;
-    decode_nint(
-        &[0x3b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
-        -18446744073709551616,
-    )?;
-    Ok(())
-}
-
-#[test]
-fn rfc8949_decode_simple_with_combinator() -> Result<(), CBORError> {
-    println!(
-        "<======================= rfc8949_decode_simple_with_combinator =====================>"
-    );
-    {
-        println!("<======================= Test with false =====================>");
-        let it = SequenceBuffer::new(&[0xf4]).into_iter();
-        let (_, r) = is_false()(it)?;
-        assert_eq!(r, CBOR::False);
-    }
-    {
-        println!("<======================= Test with true =====================>");
-        let it = SequenceBuffer::new(&[0xf5]).into_iter();
-        let (_, r) = is_true()(it)?;
-        assert_eq!(r, CBOR::True);
-    }
-    {
-        println!("<======================= Test with null =====================>");
-        let it = SequenceBuffer::new(&[0xf6]).into_iter();
-        let (_, r) = is_null()(it)?;
-        assert_eq!(r, CBOR::Null);
-    }
-    {
-        println!("<======================= Test with undefined =====================>");
-        let it = SequenceBuffer::new(&[0xf7]).into_iter();
-        let (_, r) = is_undefined()(it)?;
-        assert_eq!(r, CBOR::Undefined);
-    }
-    {
-        println!("<======================= Test with simple(16) =====================>");
-        let it = SequenceBuffer::new(&[0xf0]).into_iter();
-        let (_, r) = with_value(is_simple(), CBOR::Simple(16))(it)?;
-        assert_eq!(r, CBOR::Simple(16));
-    }
-    {
-        println!("<======================= Test with simple(255) =====================>");
-        let it = SequenceBuffer::new(&[0xf8, 0xff]).into_iter();
-        let (_, r) = with_value(is_simple(), CBOR::Simple(255))(it)?;
-        assert_eq!(r, CBOR::Simple(255));
-    }
-    {
-        println!(
-            "<======================= Test with simple(19), simple(253) =====================>"
-        );
-        let it = SequenceBuffer::new(&[0xf3, 0xf8, 0xfd]).into_iter();
-        let (it, r1) = with_value(is_simple(), CBOR::Simple(19))(it)?;
-        let (_, r2) = with_value(is_simple(), CBOR::Simple(253))(it)?;
-        assert_eq!(r1, CBOR::Simple(19));
-        assert_eq!(r2, CBOR::Simple(253));
-    }
-    Ok(())
-}
-
-#[test]
-fn rfc8949_decode_tstr_with_combinator() -> Result<(), CBORError> {
-    fn decode_str(b: &[u8], s: &str) -> Result<(), CBORError> {
-        println!(
-            "<======================= Test with {:?} =====================>",
-            s
-        );
-        let it = SequenceBuffer::new(b).into_iter();
-        let (_, r) = with_value(is_tstr(), CBOR::Tstr(s))(it)?;
-        assert_eq!(r, CBOR::Tstr(s));
-        Ok(())
-    }
-    println!("<======================= rfc8949_decode_tstr_with_combinator =====================>");
-    decode_str(&[0x60], "")?;
-    decode_str(&[0x61, 0x61], "a")?;
-    decode_str(&[0x64, 0x49, 0x45, 0x54, 0x46], "IETF")?;
-    decode_str(&[0x62, 0x22, 0x5c], "\"\\")?;
-    decode_str(&[0x62, 0xc3, 0xbc], "\u{00fc}")?;
-    decode_str(&[0x63, 0xe6, 0xb0, 0xb4], "\u{6c34}")?;
-
-    // The below is illegal as Rust requires chars to be Unicode scalar values
-    // which means that only values in [0x0, 0xd7ff] and [0xe000, 0x10ffff] are
-    // legal. In short, RFC7049 has an example which is not actually legal UTF8
-    // - see Unicode Standard, v12.0, Section 3.9, Table 3-7.
-    // decode_str(false, &[0x64, 0xf0, 0x90, 0x85, 0x91],  "\u{00d800}\u{00dd51}")?;
-    Ok(())
-}
-
-#[test]
-fn rfc8949_decode_bstr_with_combinator() -> Result<(), CBORError> {
-    fn decode_bstr(b: &[u8], bs: &[u8]) -> Result<(), CBORError> {
-        println!(
-            "<======================= Test with {:?} =====================>",
-            bs
-        );
-        let it = SequenceBuffer::new(b).into_iter();
-        let (_, r) = with_value(is_bstr(), CBOR::Bstr(bs))(it)?;
-        assert_eq!(r, CBOR::Bstr(bs));
-        Ok(())
-    }
-    println!("<======================= rfc8949_decode_str_with_combinator =====================>");
-    decode_bstr(&[0x40], &[])?;
-    decode_bstr(&[0x44, 0x01, 0x02, 0x03, 0x04], &[1, 2, 3, 4])?;
-    Ok(())
-}
-
-#[test]
-fn rfc8949_decode_array_with_combinator() -> Result<(), CBORError> {
-    println!(
-        "<======================= rfc8949_decode_array_with_combinator =====================>"
-    );
-    {
-        println!("<======================= Test with empty array =====================>");
-        let it = SequenceBuffer::new(&[0x80]).into_iter();
-        if let (_, CBOR::Array(ab)) = is_array()(it)? {
-            assert_eq!(ab.len(), 0);
-        } else {
-            assert!(false);
-        }
-    }
-    {
-        println!("<======================= Test with [1,2,3] =====================>");
-        let it_seq = SequenceBuffer::new(&[0x83, 0x01, 0x02, 0x03]).into_iter();
-        if let (_, CBOR::Array(ab)) = is_array()(it_seq)? {
-            assert_eq!(ab.len(), 3);
-            let it_array = ab.into_iter();
-            let (it_array, r1) = is_uint()(it_array)?;
-            let (it_array, r2) = is_uint()(it_array)?;
-            let (_it_array, r3) = is_uint()(it_array)?;
-            assert_eq!(r1, CBOR::UInt(1));
-            assert_eq!(r2, CBOR::UInt(2));
-            assert_eq!(r3, CBOR::UInt(3));
-        } else {
-            assert!(false);
-        }
-    }
-    {
-        println!("<======================= Test with [1,[2,3],[4,5]] =====================>");
-        let it_seq =
-            SequenceBuffer::new(&[0x83, 0x01, 0x82, 0x02, 0x03, 0x82, 0x04, 0x05]).into_iter();
-        if let (_, CBOR::Array(ab)) = is_array()(it_seq)? {
-            assert_eq!(ab.len(), 3);
-            let it_array = ab.into_iter();
-            let (it_array, r1) = is_uint()(it_array)?;
-            let (it_array, r2) = is_array()(it_array)?;
-            let (_it_array, r3) = is_array()(it_array)?;
-            assert_eq!(r1, CBOR::UInt(1));
-            if let CBOR::Array(ab2) = r2 {
-                let it_ab2 = ab2.into_iter();
-                let (it_ab2, r2a) = is_uint()(it_ab2)?;
-                let (_it_ab2, r2b) = is_uint()(it_ab2)?;
-                assert!(r2a == CBOR::UInt(2) && r2b == CBOR::UInt(3));
-            } else {
-                assert!(false);
-            }
-            if let CBOR::Array(ab3) = r3 {
-                let it_ab3 = ab3.into_iter();
-                let (it_ab3, r3a) = is_uint()(it_ab3)?;
-                let (_it_ab3, r3b) = is_uint()(it_ab3)?;
-                assert!(r3a == CBOR::UInt(4) && r3b == CBOR::UInt(5))
-            } else {
-                assert!(false);
-            }
-        } else {
-            assert!(false);
-        }
-    }
-    {
-        println!("<======================= Test with [1,2, ..., 25] =====================>");
-        let it_seq = SequenceBuffer::new(&[
-            0x98, 0x19, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
-            0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x18, 0x18,
-            0x19,
-        ])
-        .into_iter();
-        if let (_, CBOR::Array(ab)) = is_array()(it_seq)? {
-            assert_eq!(ab.len(), 25);
-            // Note slightly nasty handling of the iterator here...
-            let mut it_array = ab.into_iter();
-            for i in 0..ab.len() {
-                // The iterator is assigned here in a let, so dropped on next loop iteration...
-                let (it_array_tmp, v) = is_uint()(it_array)?;
-                // So we assign it to the mutable copy here, and the value is moved.
-                it_array = it_array_tmp;
-
-                if let CBOR::UInt(num) = v {
-                    assert_eq!((i + 1) as u64, num);
-                } else {
-                    assert!(false);
-                }
-            }
-        } else {
-            assert!(false);
-        }
-    }
-    {
-        println!(
-            "<======================= Test with [\"a\", (\"b\": \"c\")]  =====================>"
-        );
-        let it = SequenceBuffer::new(&[0x82, 0x61, 0x61, 0xa1, 0x61, 0x62, 0x61, 0x63]).into_iter();
-        if let (_, CBOR::Array(ab)) = is_array()(it)? {
-            assert_eq!(ab.len(), 2);
-            assert_eq!(ab.index(0), Some(CBOR::Tstr("a")));
-            if let Some(CBOR::Map(mb2)) = ab.index(1) {
-                assert_eq!(mb2.len(), 1);
-                assert_eq!(
-                    mb2.get_key_value(&CBOR::Tstr("b")),
-                    Some((CBOR::Tstr("b"), CBOR::Tstr("c")))
-                );
-            } else {
-                assert!(false)
-            }
-        } else {
-            assert!(false);
-        }
-    }
-
-    Ok(())
-}
-
-#[test]
-fn rfc8949_decode_map_with_combinator() -> Result<(), CBORError> {
-    println!("<======================= rfc8949_decode_map_with_combinator =====================>");
-    {
-        println!("<======================= Test with empty map =====================>");
-        let it = SequenceBuffer::new(&[0xa0]).into_iter();
-        if let (_, CBOR::Map(mb)) = is_map()(it)? {
-            assert_eq!(mb.len(), 0);
-            assert!(mb.is_empty());
-            assert_eq!(mb.contains_key(&CBOR::UInt(1)), false);
-        } else {
-            assert!(false);
-        }
-    }
-    {
-        println!("<======================= Test with (1: 2, 3: 4)  =====================>");
-        let it = SequenceBuffer::new(&[0xa2, 0x01, 0x02, 0x03, 0x04]).into_iter();
-        if let (_, CBOR::Map(mb)) = is_map()(it)? {
-            assert_eq!(mb.len(), 2);
-            assert_eq!(mb.contains_key(&CBOR::UInt(1)), true);
-            assert_eq!(mb.get(&CBOR::UInt(1)), Some(CBOR::UInt(2)));
-            assert_eq!(
-                mb.get_key_value(&CBOR::UInt(3)),
-                Some((CBOR::UInt(3), CBOR::UInt(4)))
-            );
-        } else {
-            assert!(false);
-        }
-    }
-    {
-        println!(
-            "<======================= Test with (\"a\": 1, \"b\": [2,3])  =====================>"
-        );
-        let it = SequenceBuffer::new(&[0xa2, 0x61, 0x61, 0x01, 0x61, 0x62, 0x82, 0x02, 0x03])
-            .into_iter();
-        if let (_, CBOR::Map(mb)) = is_map()(it)? {
-            assert_eq!(mb.len(), 2);
-            assert_eq!(mb.contains_key(&CBOR::Tstr("a")), true);
-            assert_eq!(mb.get(&CBOR::Tstr("a")), Some(CBOR::UInt(1)));
-            if let Some(CBOR::Array(ab2)) = mb.get(&CBOR::Tstr("b")) {
-                assert_eq!(ab2.len(), 2);
-                assert_eq!(ab2.index(0), Some(CBOR::UInt(2)));
-                assert_eq!(ab2.index(1), Some(CBOR::UInt(3)));
-            } else {
-                assert!(false)
-            }
-        } else {
-            assert!(false);
-        }
-    }
-    {
-        println!(
-            "<======================= Test with (\"a\": \"A\", \"b\": \"B\", \"c\": \"C\", \"d\": \"D\", \"e\": \"E\")  =====================>"
-        );
-        let it = SequenceBuffer::new(&[
-            0xa5, 0x61, 0x61, 0x61, 0x41, 0x61, 0x62, 0x61, 0x42, 0x61, 0x63, 0x61, 0x43, 0x61,
-            0x64, 0x61, 0x44, 0x61, 0x65, 0x61, 0x45,
-        ])
-        .into_iter();
-        if let (_, CBOR::Map(mb)) = is_map()(it)? {
-            assert_eq!(mb.len(), 5);
-            assert_eq!(mb.get(&CBOR::Tstr("a")), Some(CBOR::Tstr("A")));
-            assert_eq!(mb.get(&CBOR::Tstr("e")), Some(CBOR::Tstr("E")));
-            assert_eq!(mb.get(&CBOR::Tstr("c")), Some(CBOR::Tstr("C")));
-            assert_eq!(mb.get(&CBOR::Tstr("d")), Some(CBOR::Tstr("D")));
-            assert_eq!(mb.get(&CBOR::Tstr("b")), Some(CBOR::Tstr("B")));
-        } else {
-            assert!(false);
-        }
-    }
-    Ok(())
-}
-
-#[test]
-fn rfc8949_decode_tag_with_combinator() -> Result<(), CBORError> {
-    println!("<======================= rfc8949_decode_tag_with_combinator =====================>");
-    {
-        println!(
-            "<======================= Test with 0(\"2013-03-21T20:04:00Z\") =====================>"
-        );
-        let it = SequenceBuffer::new(&[
-            0xc0, 0x74, 0x32, 0x30, 0x31, 0x33, 0x2d, 0x30, 0x33, 0x2d, 0x32, 0x31, 0x54, 0x32,
-            0x30, 0x3a, 0x30, 0x34, 0x3a, 0x30, 0x30, 0x5a,
-        ])
-        .into_iter();
-        if let (_, CBOR::Tag(tb)) = is_tag_with_value(0)(it)? {
-            let t_it = tb.into_iter();
-            if let (_, CBOR::Tstr(s)) = is_tstr()(t_it)? {
-                assert_eq!(s, "2013-03-21T20:04:00Z");
-            } else {
-                assert!(false);
-            }
-        } else {
-            assert!(false);
-        }
-    }
-    {
-        println!("<======================= Test with 1(1363896240) =====================>");
-        let it = SequenceBuffer::new(&[0xc1, 0x1a, 0x51, 0x4b, 0x67, 0xb0]).into_iter();
-        if let (_, CBOR::Tag(tb)) = is_tag_with_value(1)(it)? {
-            let t_it = tb.into_iter();
-            if let (_, CBOR::UInt(v)) = is_uint()(t_it)? {
-                assert_eq!(v, 1363896240);
-            } else {
-                assert!(false);
-            }
-        } else {
-            assert!(false);
-        }
-    }
-    {
-        println!("<======================= Test with 23(h'01020304') =====================>");
-        let it = SequenceBuffer::new(&[0xd7, 0x44, 0x01, 0x02, 0x03, 0x04]).into_iter();
-        if let (_, CBOR::Tag(tb)) = is_tag_with_value(23)(it)? {
-            let t_it = tb.into_iter();
-            if let (_, CBOR::Bstr(bs)) = is_bstr()(t_it)? {
-                assert_eq!(bs, &[1, 2, 3, 4]);
-            } else {
-                assert!(false);
-            }
-        } else {
-            assert!(false);
-        }
-    }
-    {
-        println!("<======================= Test with 24(h'6449455446') =====================>");
-        let it = SequenceBuffer::new(&[0xd8, 0x18, 0x45, 0x64, 0x49, 0x45, 0x54, 0x46]).into_iter();
-        if let (_, CBOR::Tag(tb)) = is_tag_with_value(24)(it)? {
-            let t_it = tb.into_iter();
-            if let (_, CBOR::Bstr(bs)) = is_bstr()(t_it)? {
-                assert_eq!(bs, &[0x64, 0x49, 0x45, 0x54, 0x46]);
-            } else {
-                assert!(false);
-            }
-        } else {
-            assert!(false);
-        }
-    }
-    {
-        println!("<======================= Test with 32(\"http://www.example.com\") =====================>");
-        let it = SequenceBuffer::new(&[
-            0xd8, 0x20, 0x76, 0x68, 0x74, 0x74, 0x70, 0x3a, 0x2f, 0x2f, 0x77, 0x77, 0x77, 0x2e,
-            0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d,
-        ])
-        .into_iter();
-        if let (_, CBOR::Tag(tb)) = is_tag_with_value(32)(it)? {
-            let t_it = tb.into_iter();
-            if let (_, CBOR::Tstr(ts)) = is_tstr()(t_it)? {
-                assert_eq!(ts, "http://www.example.com");
-            } else {
-                assert!(false);
-            }
-        } else {
-            assert!(false);
-        }
-    }
-    Ok(())
-}
-
-#[test]
-fn rfc8949_decode_float_manual() {
+fn rfc8949_decode_float() {
     println!("<======================= rfc8949_decode_float =====================>");
 
     // Tests for f16 encodings
@@ -1010,7 +535,7 @@ fn rfc8949_decode_float_manual() {
         ([0xf9, 0x04, 0x00], 0.00006103515625),
         ([0xf9, 0xc4, 0x00], -4.0),
     ]
-    .iter()
+        .iter()
     {
         println!(
             "<======================= Test with {} (f16) =====================>",
@@ -1047,7 +572,7 @@ fn rfc8949_decode_float_manual() {
         ([0xfa, 0x47, 0xc3, 0x50, 0x00], 100000.0),
         ([0xfa, 0x7f, 0x7f, 0xff, 0xff], 3.4028234663852886e+38f32),
     ]
-    .iter()
+        .iter()
     {
         println!(
             "<======================= Test with {} (f32) =====================>",
@@ -1088,7 +613,7 @@ fn rfc8949_decode_float_manual() {
         ),
         ([0xfb, 0xc0, 0x10, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66], -4.1),
     ]
-    .iter()
+        .iter()
     {
         println!(
             "<======================= Test with {} (f64) =====================>",
@@ -1103,7 +628,7 @@ fn rfc8949_decode_float_manual() {
 
     println!("<======================= Test +Infinity (f64) =====================>");
     if let Some(CBOR::Float64(v)) =
-        decode_single(&[0xfb, 0x7f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+    decode_single(&[0xfb, 0x7f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
     {
         assert!(v.is_infinite() && v.is_sign_positive());
     } else {
@@ -1111,7 +636,7 @@ fn rfc8949_decode_float_manual() {
     }
     println!("<======================= Test NaN (f64) =====================>");
     if let Some(CBOR::Float64(v)) =
-        decode_single(&[0xfb, 0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+    decode_single(&[0xfb, 0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
     {
         assert!(v.is_nan());
     } else {
@@ -1119,7 +644,7 @@ fn rfc8949_decode_float_manual() {
     }
     println!("<======================= Test -Infinity (f64) =====================>");
     if let Some(CBOR::Float64(v)) =
-        decode_single(&[0xfb, 0xff, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+    decode_single(&[0xfb, 0xff, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
     {
         assert!(v.is_infinite() && v.is_sign_negative());
     } else {

--- a/tps_minicbor/tests/rfc8949_encode.rs
+++ b/tps_minicbor/tests/rfc8949_encode.rs
@@ -19,13 +19,12 @@
 /***************************************************************************************************
  * Test cases from RFC8949, for encoding
  *
- * Test cases from RFC7049, Table 4.
+ * Test cases from RFC7049, Table 6.
  **************************************************************************************************/
 
 extern crate tps_minicbor;
 
 use half::f16;
-use tps_minicbor::decoder::*;
 use tps_minicbor::encoder::*;
 use tps_minicbor::error::CBORError;
 use tps_minicbor::types::{array, map, tag, CBOR};
@@ -428,7 +427,10 @@ fn rfc8949_encode_float() -> Result<(), CBORError> {
         let mut buf = EncodeBuffer::new(&mut bytes);
         let val = &(1.1);
         val.encode(&mut buf)?;
-        assert_eq!(buf.encoded()?, &[0xfb, 0x3f, 0xf1, 0x99, 0x99, 0x99, 0x99, 0x99, 0x9a]);
+        assert_eq!(
+            buf.encoded()?,
+            &[0xfb, 0x3f, 0xf1, 0x99, 0x99, 0x99, 0x99, 0x99, 0x9a]
+        );
     }
     {
         let mut buf = EncodeBuffer::new(&mut bytes);
@@ -458,7 +460,10 @@ fn rfc8949_encode_float() -> Result<(), CBORError> {
         let mut buf = EncodeBuffer::new(&mut bytes);
         let val = &(1.0e+300);
         val.encode(&mut buf)?;
-        assert_eq!(buf.encoded()?, &[0xfb, 0x7e, 0x37, 0xe4, 0x3c, 0x88, 0x00, 0x75, 0x9c]);
+        assert_eq!(
+            buf.encoded()?,
+            &[0xfb, 0x7e, 0x37, 0xe4, 0x3c, 0x88, 0x00, 0x75, 0x9c]
+        );
     }
     {
         let mut buf = EncodeBuffer::new(&mut bytes);
@@ -482,7 +487,10 @@ fn rfc8949_encode_float() -> Result<(), CBORError> {
         let mut buf = EncodeBuffer::new(&mut bytes);
         let val = &(-4.1);
         val.encode(&mut buf)?;
-        assert_eq!(buf.encoded()?, &[0xfb, 0xc0, 0x10, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66]);
+        assert_eq!(
+            buf.encoded()?,
+            &[0xfb, 0xc0, 0x10, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66]
+        );
     }
     {
         let mut buf = EncodeBuffer::new(&mut bytes);
@@ -513,18 +521,14 @@ fn rfc8949_encode_tag() -> Result<(), CBORError> {
         let expected: &[u8] = &[0xc1, 0x1a, 0x51, 0x4b, 0x67, 0xb0];
 
         let mut encoder = CBORBuilder::new(&mut buffer);
-        let _ = encoder.insert(&tag(1, |buff| {
-            buff.insert(&1363896240)
-        }))?;
+        let _ = encoder.insert(&tag(1, |buff| buff.insert(&1363896240)))?;
         assert_eq!(encoder.encoded()?, expected);
     }
     {
         let expected: &[u8] = &[0xc1, 0xfb, 0x41, 0xd4, 0x52, 0xd9, 0xec, 0x20, 0x00, 0x00];
 
         let mut encoder = CBORBuilder::new(&mut buffer);
-        let _ = encoder.insert(&tag(1, |buff| {
-            buff.insert(&1363896240.5)
-        }))?;
+        let _ = encoder.insert(&tag(1, |buff| buff.insert(&1363896240.5)))?;
         assert_eq!(encoder.encoded()?, expected);
     }
     {
@@ -544,7 +548,6 @@ fn rfc8949_encode_tag() -> Result<(), CBORError> {
             buff.insert(&[1u8, 2u8, 3u8, 4u8].as_slice())
         }))?;
         assert_eq!(encoder.encoded()?, expected);
-
     }
     Ok(())
 }
@@ -710,207 +713,4 @@ fn rfc8949_encode_map_long() -> Result<(), CBORError> {
     Ok(())
 }
 
-#[test]
-fn encode_decode_cbor_ast() -> Result<(), CBORError> {
-    // Encode-decode round trip test
-    println!("<======================= encode_decode_cbor_ast =====================>");
-    let mut bytes = [0u8; 128];
 
-    {
-        let val: &[u8] = &[1, 2, 3, 4];
-
-        // values
-        let s1 = CBOR::Simple(17);
-        let s2 = CBOR::Simple(234);
-        let s3 = CBOR::False;
-        let tval = CBOR::UInt(0x5a5a5a5a5a5a);
-        let aval1 = CBOR::Tstr("usine à gaz");
-        let aval2 = CBOR::UInt(42);
-        let aval3 = CBOR::Undefined;
-        let mkey1 = CBOR::UInt(1);
-        let mval1 = CBOR::UInt(1023);
-        let mkey2 = CBOR::UInt(2);
-        let mval2 = CBOR::UInt(1025);
-        let mkey3 = CBOR::NInt(1);
-        let mval3 = CBOR::NInt(1024);
-        let mut tag_val: u64 = 0;
-
-        let mut encoded_cbor = CBORBuilder::new(&mut bytes);
-        encoded_cbor
-            .insert(&32u8)?
-            .insert(&(-(0xa5a5a5i32)))?
-            .insert(&"新年快乐")?
-            .insert(&val)?
-            .insert(&s1)?
-            .insert(&s2)?
-            .insert(&s3)?
-            .insert(&tag(37, |buf| buf.insert(&tval)))?
-            .insert(&array(|buf| {
-                buf.insert(&"usine à gaz")?
-                    .insert(&42u8)?
-                    .insert(&CBOR::Undefined)
-            }))?
-            .insert(&map(|buf| {
-                buf.insert_key_value(&1u8, &1023u32)?
-                    .insert_key_value(&2u8, &1025u32)?
-                    .insert_key_value(&(-1i8), &(-1024i32))
-            }))?;
-
-        let _decoder = CBORDecoder::new(encoded_cbor.build()?)
-            .decode_with(is_uint(), |cbor| {
-                Ok(assert_eq!(cbor.try_into_u32()?, 32u32))
-            })?
-            .decode_with(is_nint(), |cbor| {
-                Ok(assert_eq!(cbor.try_into_i32()?, -(0xa5a5a5i32)))
-            })?
-            .decode_with(is_tstr(), |cbor| {
-                Ok(assert_eq!(cbor.try_into_str()?, "新年快乐"))
-            })?
-            .decode_with(is_bstr(), |cbor| {
-                Ok(assert_eq!(cbor.try_into_u8slice()?, val))
-            })?
-            .decode_with(is_simple(), |cbor| Ok(assert_eq!(cbor, s1)))?
-            .decode_with(is_simple(), |cbor| Ok(assert_eq!(cbor, s2)))?
-            .decode_with(is_false(), |cbor| Ok(assert_eq!(cbor, s3)))?
-            .decode_with(is_tag(), |cbor| {
-                CBORDecoder::from_tag(cbor, &mut tag_val)?
-                    .decode_with(is_uint(), |cbor| Ok(assert_eq!(cbor, tval)))?
-                    .finalize()
-            })?
-            .decode_with(is_array(), |cbor| {
-                CBORDecoder::from_array(cbor)?
-                    .decode_with(is_tstr(), |cbor| Ok(assert_eq!(cbor, aval1)))?
-                    .decode_with(is_uint(), |cbor| Ok(assert_eq!(cbor, aval2)))?
-                    .decode_with(is_undefined(), |cbor| Ok(assert_eq!(cbor, aval3)))?
-                    .finalize()
-            })?
-            .decode_with(is_map(), |cbor| {
-                if let CBOR::Map(mb) = cbor {
-                    // In the test cases we do not care about the results of these - the assert_eq!()
-                    // tell us all we need.
-                    let _ = mb.get(&mkey1).map_or_else(
-                        || Err(CBORError::KeyNotPresent),
-                        |v| Ok(assert_eq!(v, mval1)),
-                    );
-                    let _ = mb.get(&mkey2).map_or_else(
-                        || Err(CBORError::KeyNotPresent),
-                        |v| Ok(assert_eq!(v, mval2)),
-                    );
-                    let _ = mb.get(&mkey3).map_or_else(
-                        || Err(CBORError::KeyNotPresent),
-                        |v| Ok(assert_eq!(v, mval3)),
-                    );
-                    Ok(())
-                } else {
-                    Err(CBORError::ExpectedType("Map"))
-                }
-            })?;
-    }
-    Ok(())
-}
-
-// / This is an example of a token produced by a HW block            /
-// / purpose-built for attestation.  Only the nonce claim changes    /
-// / from one attestation to the next as the rest  either come       /
-// / directly from the hardware or from one-time-programmable memory /
-// / (e.g. a fuse). 47 bytes encoded in CBOR (8 byte nonce, 16 byte  /
-// / UEID). /
-//
-// {
-// / nonce /           10: h'948f8860d13a463e',
-// / UEID /           256: h'0198f50a4ff6c05861c8860d13a638ea',
-// / OEMID /          258: 64242, / Private Enterprise Number /
-// / security-level / 261: 3, / hardware level security /
-// / secure-boot /    262: true,
-// / debug-status /   263: 3, / disabled-permanently /
-// / HW version /     260: [ "3.1", 1 ] / Type is multipartnumeric /
-// }
-#[test]
-fn encode_tee_eat() -> Result<(), CBORError> {
-    // Encode-decode round trip test
-    println!("<========================== encode_tee_eat =========================>");
-    let mut bytes = [0u8; 1024];
-    let expected: &[u8] = &[
-        167, 10, 72, 148, 143, 136, 96, 209, 58, 70, 62, 25, 1, 0, 80, 1, 152, 245, 10, 79, 246,
-        192, 88, 97, 200, 134, 13, 19, 166, 56, 234, 25, 1, 2, 25, 250, 242, 25, 1, 5, 3, 25, 1, 6,
-        245, 25, 1, 7, 3, 25, 1, 4, 130, 99, 51, 46, 49, 1,
-    ];
-    let nonce: &[u8] = &[0x94, 0x8f, 0x88, 0x60, 0xd1, 0x3a, 0x46, 0x3e];
-    let ueid: &[u8] = &[
-        0x01, 0x98, 0xf5, 0x0a, 0x4f, 0xf6, 0xc0, 0x58, 0x61, 0xc8, 0x86, 0x0d, 0x13, 0xa6, 0x38,
-        0xea,
-    ];
-
-    let mut encoded_cbor = CBORBuilder::new(&mut bytes);
-    encoded_cbor.insert(&map(|buff| {
-        buff.insert_key_value(&10, &nonce)?
-            .insert_key_value(&256, &ueid)?
-            .insert_key_value(&258, &64242)?
-            .insert_key_value(&261, &3)?
-            .insert_key_value(&262, &true)?
-            .insert_key_value(&263, &3)?
-            .insert_key_value(&260, &array(|buf| buf.insert(&"3.1")?.insert(&1)))
-    }))?;
-
-    assert_eq!(encoded_cbor.encoded()?, expected);
-    Ok(())
-}
-
-#[test]
-fn decode_tee_eat() -> Result<(), CBORError> {
-    let mut input: &[u8] = &[
-        167, 10, 72, 148, 143, 136, 96, 209, 58, 70, 62, 25, 1, 0, 80, 1, 152, 245, 10, 79, 246,
-        192, 88, 97, 200, 134, 13, 19, 166, 56, 234, 25, 1, 2, 25, 250, 242, 25, 1, 5, 3, 25, 1, 6,
-        245, 25, 1, 7, 3, 25, 1, 4, 130, 99, 51, 46, 49, 1,
-    ];
-    let mut nonce = None;
-    let mut ueid = None;
-    let mut oemid = None;
-    let mut sec_level = None;
-    let mut sec_boot = None;
-    let mut debug_state = None;
-    let mut hw_ver_int = None;
-
-    let mut decoder = CBORDecoder::from_slice(&mut input);
-    decoder.decode_with(is_map(), |cbor| {
-        if let CBOR::Map(map) = cbor {
-            nonce = map.get_int(10);
-            ueid = map.get_int(256);
-            oemid = map.get_int(258);
-            sec_level = map.get_int(261);
-            sec_boot = map.get_int(262);
-            debug_state = map.get_int(263);
-            if let Some(CBOR::Array(ab)) = map.get_int(260) {
-                hw_ver_int = match ab.index(1) {
-                    None => None,
-                    Some(CBOR::UInt(vi)) => Some(vi.clone()),
-                    _ => None
-                };
-            }
-        }
-        Ok(())
-    })?;
-
-    assert_eq!(oemid, Some(CBOR::UInt(64242)));
-    assert_eq!(sec_level, Some(CBOR::UInt(3)));
-    assert_eq!(sec_boot, Some(CBOR::True));
-    assert_eq!(debug_state, Some(CBOR::UInt(3)));
-    assert_eq!(hw_ver_int, Some(1));
-    Ok(())
-}
-
-#[test]
-fn encode_array_array() -> Result<(), CBORError> {
-
-    println!("<=================== rfc8949_encode_nested_array ===================>");
-    let mut buffer = [0u8; 64];
-    let expected: &[u8] = &[130, 130, 1, 2, 130, 3, 4];
-
-    let mut encoder = CBORBuilder::new(&mut buffer);
-    let _ = encoder.insert(&array(|buff| {
-        buff.insert(&array(|buff| buff.insert(&1u8)?.insert(&2u8)))?
-            .insert(&array(|buff| buff.insert(&3u8)?.insert(&4u8)))
-    }))?;
-    assert_eq!(encoder.encoded()?, expected);
-    Ok(())
-}


### PR DESCRIPTION
- Significant enhancements to CBOR Decoder API which significantly shorten the code needed to write decoders, and make it cleave closer to CDDl definitions.
- Updated Trivial COSE example to use the improved API
- Enhanced decoder high-level tests to use the new API
- Added support for new API in Map, Array and Tag structures
- Added TryFrom instances for MapBuf and ArrayBuf
- Added examples for the APIs most likely to be called by users
- Added a new IndexOutOfBounds error for array errors
- Re-organized test cases to split tests from RFC8949 from other tests, and to separate tests using the high and low level decoder APIs

Signed-off-by: Jeremy O'Donoghue <quic_jodonogh@quicinc.com>